### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-bpsv"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "serde",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-cache"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes",
  "criterion",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-cdn"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes",
  "criterion",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "ribbit-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "asn1",
  "base64",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "tact-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "ngdp-bpsv",

--- a/ngdp-bpsv/CHANGELOG.md
+++ b/ngdp-bpsv/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-bpsv-v0.1.0...ngdp-bpsv-v0.1.1) - 2025-06-29
+
+### Other
+
+- 🐛 fix: all the cargo checks we can find
+- 🐛 fix: correct HEX field declarations in parse_basic example

--- a/ngdp-bpsv/Cargo.toml
+++ b/ngdp-bpsv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-bpsv"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/ngdp-cache/CHANGELOG.md
+++ b/ngdp-cache/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.0...ngdp-cache-v0.1.1) - 2025-06-29
+
+### Other
+
+- 🔧 chore: replace OpenSSL with rustls for cross-platform builds

--- a/ngdp-cache/Cargo.toml
+++ b/ngdp-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-cache"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,12 +15,12 @@ categories = ["caching", "filesystem", "games"]
 bytes = "1.8"
 dirs = { workspace = true }
 futures = "0.3"
-ngdp-cdn = { path = "../ngdp-cdn", version = "0.1.0" }
+ngdp-cdn = { path = "../ngdp-cdn", version = "0.1.1" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-ribbit-client = { path = "../ribbit-client", version = "0.1.0" }
+ribbit-client = { path = "../ribbit-client", version = "0.1.1" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
-tact-client = { path = "../tact-client", version = "0.1.0" }
+tact-client = { path = "../tact-client", version = "0.1.1" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
 tracing = { workspace = true }

--- a/ngdp-cdn/CHANGELOG.md
+++ b/ngdp-cdn/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cdn-v0.1.0...ngdp-cdn-v0.1.1) - 2025-06-29
+
+### Other
+
+- 🔧 chore: replace OpenSSL with rustls for cross-platform builds
+- 🐛 fix: all the cargo checks we can find

--- a/ngdp-cdn/Cargo.toml
+++ b/ngdp-cdn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-cdn"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/ngdp-client/CHANGELOG.md
+++ b/ngdp-client/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.1.0...ngdp-client-v0.1.1) - 2025-06-29
+
+### Other
+
+- 🔧 chore: replace OpenSSL with rustls for cross-platform builds

--- a/ngdp-client/Cargo.toml
+++ b/ngdp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-client"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -23,10 +23,10 @@ path = "src/main.rs"
 clap = { workspace = true, features = ["derive", "cargo", "env"] }
 comfy-table = "7.1.1"
 owo-colors = { version = "4.2.1", features = ["supports-colors"] }
-ribbit-client = { path = "../ribbit-client", version = "0.1.0" }
-tact-client = { path = "../tact-client", version = "0.1.0" }
-ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.0" }
-ngdp-cache = { path = "../ngdp-cache", version = "0.1.0" }
+ribbit-client = { path = "../ribbit-client", version = "0.1.1" }
+tact-client = { path = "../tact-client", version = "0.1.1" }
+ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.1" }
+ngdp-cache = { path = "../ngdp-cache", version = "0.1.1" }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/ribbit-client/CHANGELOG.md
+++ b/ribbit-client/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.1.0...ribbit-client-v0.1.1) - 2025-06-29
+
+### Other
+
+- updated the following local packages: ngdp-bpsv

--- a/ribbit-client/Cargo.toml
+++ b/ribbit-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ribbit-client"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -24,7 +24,7 @@ digest = "0.10"
 dirs.workspace = true
 hex = "0.4"
 mail-parser = "0.11"
-ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.0" }
+ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.1" }
 rand.workspace = true
 rsa = { version = "0.9", features = ["sha2"] }
 sha2 = "0.10"

--- a/tact-client/CHANGELOG.md
+++ b/tact-client/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/tact-client-v0.1.0...tact-client-v0.1.1) - 2025-06-29
+
+### Other
+
+- 🔧 chore: replace OpenSSL with rustls for cross-platform builds

--- a/tact-client/Cargo.toml
+++ b/tact-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact-client"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ categories = [
 ]
 
 [dependencies]
-ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.0" }
+ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.1" }
 rand.workspace = true
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 thiserror.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `ngdp-bpsv`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `ngdp-cdn`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `tact-client`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `ngdp-cache`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `ngdp-client`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `ribbit-client`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `ngdp-bpsv`

<blockquote>

## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-bpsv-v0.1.0...ngdp-bpsv-v0.1.1) - 2025-06-29

### Other

- 🐛 fix: all the cargo checks we can find
- 🐛 fix: correct HEX field declarations in parse_basic example
</blockquote>

## `ngdp-cdn`

<blockquote>

## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cdn-v0.1.0...ngdp-cdn-v0.1.1) - 2025-06-29

### Other

- 🔧 chore: replace OpenSSL with rustls for cross-platform builds
- 🐛 fix: all the cargo checks we can find
</blockquote>

## `tact-client`

<blockquote>

## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/tact-client-v0.1.0...tact-client-v0.1.1) - 2025-06-29

### Other

- 🔧 chore: replace OpenSSL with rustls for cross-platform builds
</blockquote>

## `ngdp-cache`

<blockquote>

## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.0...ngdp-cache-v0.1.1) - 2025-06-29

### Other

- 🔧 chore: replace OpenSSL with rustls for cross-platform builds
</blockquote>

## `ngdp-client`

<blockquote>

## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.1.0...ngdp-client-v0.1.1) - 2025-06-29

### Other

- 🔧 chore: replace OpenSSL with rustls for cross-platform builds
</blockquote>

## `ribbit-client`

<blockquote>

## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.1.0...ribbit-client-v0.1.1) - 2025-06-29

### Other

- updated the following local packages: ngdp-bpsv
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).