### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-bpsv"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "criterion",
  "serde",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-cache"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "criterion",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-cdn"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "criterion",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-client"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "ribbit-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "asn1",
  "base64",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "tact-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "criterion",
  "ngdp-bpsv",

--- a/ngdp-bpsv/CHANGELOG.md
+++ b/ngdp-bpsv/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-bpsv-v0.1.1...ngdp-bpsv-v0.1.2) - 2025-07-15
+
+### Other
+
+- 📝 docs: synchronize individual crate changelogs with main changelog
+
 ### Fixed
 
 - **parse_basic example**:

--- a/ngdp-bpsv/Cargo.toml
+++ b/ngdp-bpsv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-bpsv"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/ngdp-cache/CHANGELOG.md
+++ b/ngdp-cache/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.2...ngdp-cache-v0.1.3) - 2025-07-15
+
+### Other
+
+- updated the following local packages: ngdp-cdn, ribbit-client, tact-client
+
 ## [0.1.2](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.1...ngdp-cache-v0.1.2) - 2025-07-05
 
 ### Other

--- a/ngdp-cache/Cargo.toml
+++ b/ngdp-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-cache"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,12 +15,12 @@ categories = ["caching", "filesystem", "games"]
 bytes = "1.8"
 dirs = { workspace = true }
 futures = "0.3"
-ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.0" }
+ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.1" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-ribbit-client = { path = "../ribbit-client", version = "0.1.1" }
+ribbit-client = { path = "../ribbit-client", version = "0.1.2" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
-tact-client = { path = "../tact-client", version = "0.1.1" }
+tact-client = { path = "../tact-client", version = "0.1.2" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
 tracing = { workspace = true }

--- a/ngdp-cdn/CHANGELOG.md
+++ b/ngdp-cdn/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cdn-v0.2.0...ngdp-cdn-v0.2.1) - 2025-07-15
+
+### Other
+
+- 📝 docs: synchronize individual crate changelogs with main changelog
+
 ### Added
 
 - **Enhanced CDN fallback support**:

--- a/ngdp-cdn/Cargo.toml
+++ b/ngdp-cdn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-cdn"
-version = "0.2.0"
+version = "0.2.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/ngdp-client/CHANGELOG.md
+++ b/ngdp-client/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.1.2...ngdp-client-v0.2.0) - 2025-07-15
+
+### Other
+
+- 🔧 fix: resolve clippy warnings and apply code formatting
+- 📝 docs: synchronize individual crate changelogs with main changelog
+- ✨ feat(ngdp-client): enhance config show to display all settings
+- 🩹 fix(ngdp-client): resolve critical -o flag conflict in download commands
+- 🩹 fix(ngdp-client): resolve conflicting short command-line flags
+- ✨ feat(ngdp-client): add products builds command with Wago Tools API integration
+
 ### Added
 
 - **Historical builds command**:

--- a/ngdp-client/Cargo.toml
+++ b/ngdp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-client"
-version = "0.1.2"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -23,11 +23,11 @@ path = "src/main.rs"
 clap = { workspace = true, features = ["derive", "cargo", "env"] }
 comfy-table = "7.1.1"
 owo-colors = { version = "4.2.1", features = ["supports-colors"] }
-ribbit-client = { path = "../ribbit-client", version = "0.1.1" }
-tact-client = { path = "../tact-client", version = "0.1.1" }
-ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.1" }
-ngdp-cache = { path = "../ngdp-cache", version = "0.1.2" }
-ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.0" }
+ribbit-client = { path = "../ribbit-client", version = "0.1.2" }
+tact-client = { path = "../tact-client", version = "0.1.2" }
+ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.2" }
+ngdp-cache = { path = "../ngdp-cache", version = "0.1.3" }
+ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.1" }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/ribbit-client/CHANGELOG.md
+++ b/ribbit-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.1.1...ribbit-client-v0.1.2) - 2025-07-15
+
+### Other
+
+- updated the following local packages: ngdp-bpsv
+
 ## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.1.0...ribbit-client-v0.1.1) - 2025-06-29
 
 ### Other

--- a/ribbit-client/Cargo.toml
+++ b/ribbit-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ribbit-client"
-version = "0.1.1"
+version = "0.1.2"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -24,7 +24,7 @@ digest = "0.10"
 dirs.workspace = true
 hex = "0.4"
 mail-parser = "0.11"
-ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.1" }
+ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.2" }
 rand.workspace = true
 rsa = { version = "0.9", features = ["sha2"] }
 sha2 = "0.10"

--- a/tact-client/CHANGELOG.md
+++ b/tact-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/wowemulation-dev/cascette-rs/compare/tact-client-v0.1.1...tact-client-v0.1.2) - 2025-07-15
+
+### Other
+
+- updated the following local packages: ngdp-bpsv
+
 ## [0.1.1](https://github.com/wowemulation-dev/cascette-rs/compare/tact-client-v0.1.0...tact-client-v0.1.1) - 2025-06-29
 
 ### Other

--- a/tact-client/Cargo.toml
+++ b/tact-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact-client"
-version = "0.1.1"
+version = "0.1.2"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ categories = [
 ]
 
 [dependencies]
-ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.1" }
+ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.2" }
 rand.workspace = true
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 thiserror.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `ngdp-bpsv`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `ngdp-cdn`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `ngdp-client`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `ribbit-client`: 0.1.1 -> 0.1.2
* `tact-client`: 0.1.1 -> 0.1.2
* `ngdp-cache`: 0.1.2 -> 0.1.3

### ⚠ `ngdp-client` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant ProductsCommands:Builds in /tmp/.tmpDAenex/cascette-rs/ngdp-client/src/lib.rs:77
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `ngdp-bpsv`

<blockquote>

## [0.1.2](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-bpsv-v0.1.1...ngdp-bpsv-v0.1.2) - 2025-07-15

### Other

- 📝 docs: synchronize individual crate changelogs with main changelog

### Fixed

- **parse_basic example**:
  - Corrected HEX field declarations from HEX:32 to HEX:16 to match actual data
  - Example now runs successfully without validation errors
</blockquote>

## `ngdp-cdn`

<blockquote>

## [0.2.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cdn-v0.2.0...ngdp-cdn-v0.2.1) - 2025-07-15

### Other

- 📝 docs: synchronize individual crate changelogs with main changelog

### Added

- **Enhanced CDN fallback support**:
  - Support for custom CDN fallbacks via `add_custom_cdn()` and `set_custom_cdns()` methods
  - Custom CDNs are tried after primary and community CDNs in fallback order
  - New `custom_cdn_hosts` field in `CdnClientWithFallback` for user-defined hosts
  - Builder support for custom CDNs with `add_custom_cdn()` and `add_custom_cdns()` methods
  - `clear_cdns()` now clears custom CDN hosts as well
  - Full support for custom CDN configuration in builder pattern
</blockquote>

## `ngdp-client`

<blockquote>

## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.1.2...ngdp-client-v0.2.0) - 2025-07-15

### Other

- 🔧 fix: resolve clippy warnings and apply code formatting
- 📝 docs: synchronize individual crate changelogs with main changelog
- ✨ feat(ngdp-client): enhance config show to display all settings
- 🩹 fix(ngdp-client): resolve critical -o flag conflict in download commands
- 🩹 fix(ngdp-client): resolve conflicting short command-line flags
- ✨ feat(ngdp-client): add products builds command with Wago Tools API integration

### Added

- **Historical builds command**:
  - Added `ngdp products builds` command to retrieve all historical builds for a product
  - Integrates with Wago Tools API (https://wago.tools/api/builds) for comprehensive build history
  - Support for filtering by version pattern with `--filter`
  - Time-based filtering with `--days` option
  - Result limiting with `--limit` option
  - Background download builds filtering with `--bgdl-only`
  - Displays build version, creation date, build config, and type (Full/BGDL)
  - Support for JSON, BPSV, and formatted text output
  - Caching support with 30-minute TTL to reduce API load
  - Respects global cache settings (`--no-cache` and `--clear-cache` flags)

- **Custom CDN fallback configuration**:
  - New `custom_cdn_fallbacks` configuration option for user-defined CDN hosts
  - Custom CDNs are tried after Blizzard and community CDNs have been exhausted
  - Integration with `CdnClientWithFallback` through new `cdn_config` module
  - Custom CDNs can be configured as comma-separated list in settings

### Fixed

- **Conflicting short command-line flags**:
  - Removed `-l` short flag from `--limit` in `products builds` command (was conflicting with `-l` for `--log-level`)
  - Removed `-d` short flag from `--days` in `products builds` command (was conflicting with `-d` for `--details` in `certs download`)
  - Removed `-o` short flag from `--output` in `download build` and `download files` commands (was conflicting with global `-o` for `--format`)

- **Enhanced `config show` command**:
  - Now shows all available settings with their default values, not just the three basic ones
  - Added settings: `cache_enabled`, `cache_ttl`, `max_concurrent_downloads`, `user_agent`, `verify_certificates`, `proxy_url`, `ribbit_timeout`, `tact_timeout`, `retry_attempts`, `log_file`, `color_output`, `fallback_to_tact`, `use_community_cdn_fallbacks`, `custom_cdn_fallbacks`
  - All settings are now accessible via `config get` command

- **Code quality improvements**:
  - Fixed clippy warnings in examples (uninlined_format_args)
  - Applied consistent code formatting
</blockquote>

## `ribbit-client`

<blockquote>

## [0.1.2](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.1.1...ribbit-client-v0.1.2) - 2025-07-15

### Other

- updated the following local packages: ngdp-bpsv
</blockquote>

## `tact-client`

<blockquote>

## [0.1.2](https://github.com/wowemulation-dev/cascette-rs/compare/tact-client-v0.1.1...tact-client-v0.1.2) - 2025-07-15

### Other

- updated the following local packages: ngdp-bpsv
</blockquote>

## `ngdp-cache`

<blockquote>

## [0.1.3](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.2...ngdp-cache-v0.1.3) - 2025-07-15

### Other

- updated the following local packages: ngdp-cdn, ribbit-client, tact-client
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).