### PR TITLE
fix: path tests on non-Linux platforms

### DIFF
--- a/ngdp-cache/src/cached_tact_client.rs
+++ b/ngdp-cache/src/cached_tact_client.rs
@@ -641,17 +641,10 @@ mod tests {
                 .unwrap();
 
             let path = client.get_cache_path("wow", TactEndpoint::Versions, Some(12345));
-            assert!(
-                path.to_string_lossy()
-                    .contains("us/v1/wow/versions-12345.bpsv")
-            );
+            assert!(path.ends_with("us/v1/wow/versions-12345.bpsv"));
 
             let path_no_seq = client.get_cache_path("d3", TactEndpoint::Cdns, None);
-            assert!(
-                path_no_seq
-                    .to_string_lossy()
-                    .contains("us/v1/d3/cdns-0.bpsv")
-            );
+            assert!(path_no_seq.ends_with("us/v1/d3/cdns-0.bpsv"));
         });
     }
 

--- a/ngdp-cache/src/cdn.rs
+++ b/ngdp-cache/src/cdn.rs
@@ -378,17 +378,16 @@ mod tests {
         let hash = "deadbeef1234567890abcdef12345678";
 
         let config_path = cache.config_path(hash);
-        assert!(config_path.to_str().unwrap().contains("config/de/ad"));
+        assert!(config_path.ends_with("config/de/ad/deadbeef1234567890abcdef12345678"));
 
         let data_path = cache.data_path(hash);
-        assert!(data_path.to_str().unwrap().contains("data/de/ad"));
+        assert!(data_path.ends_with("data/de/ad/deadbeef1234567890abcdef12345678"));
 
         let patch_path = cache.patch_path(hash);
-        assert!(patch_path.to_str().unwrap().contains("patch/de/ad"));
+        assert!(patch_path.ends_with("patch/de/ad/deadbeef1234567890abcdef12345678"));
 
         let index_path = cache.index_path(hash);
-        assert!(index_path.to_str().unwrap().contains("data/de/ad"));
-        assert!(index_path.to_str().unwrap().ends_with(".index"));
+        assert!(index_path.ends_with("data/de/ad/deadbeef1234567890abcdef12345678.index"));
     }
 
     #[tokio::test]
@@ -398,24 +397,19 @@ mod tests {
         let hash = "deadbeef1234567890abcdef12345678";
 
         let config_path = cache.config_path(hash);
-        assert!(
-            config_path
-                .to_str()
-                .unwrap()
-                .contains("tpr/wow/config/de/ad")
-        );
+        assert!(config_path.ends_with("tpr/wow/config/de/ad/deadbeef1234567890abcdef12345678"));
 
         let data_path = cache.data_path(hash);
-        assert!(data_path.to_str().unwrap().contains("tpr/wow/data/de/ad"));
+        assert!(data_path.ends_with("tpr/wow/data/de/ad/deadbeef1234567890abcdef12345678"));
 
         let patch_path = cache.patch_path(hash);
-        assert!(patch_path.to_str().unwrap().contains("tpr/wow/patch/de/ad"));
+        assert!(patch_path.ends_with("tpr/wow/patch/de/ad/deadbeef1234567890abcdef12345678"));
     }
 
     #[tokio::test]
     async fn test_cdn_product_cache() {
         let cache = CdnCache::for_product("wow").await.unwrap();
-        assert!(cache.base_dir().to_str().unwrap().contains("cdn/wow"));
+        assert!(cache.base_dir().ends_with("cdn/wow"));
     }
 
     #[tokio::test]

--- a/ngdp-cache/tests/cache_validity_test.rs
+++ b/ngdp-cache/tests/cache_validity_test.rs
@@ -1,8 +1,11 @@
 //! Test that cached data is still valid and being used
 
+#[cfg(target_os = "linux")]
 use ngdp_cache::{generic::GenericCache, ribbit::RibbitCache};
+#[cfg(target_os = "linux")]
 use tempfile::TempDir;
 
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_cache_ttl_and_validity() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
@@ -43,6 +46,7 @@ async fn test_cache_ttl_and_validity() -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_generic_cache_performance() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
@@ -79,6 +83,7 @@ async fn test_generic_cache_performance() -> Result<(), Box<dyn std::error::Erro
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_cache_file_structure() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;

--- a/ngdp-cache/tests/ribbit_cache_structure_test.rs
+++ b/ngdp-cache/tests/ribbit_cache_structure_test.rs
@@ -3,9 +3,12 @@
 //! This test demonstrates that CachedRibbitClient uses the correct
 //! cache directory structure: ~/.cache/ngdp/ribbit/{region}/
 
+#[cfg(target_os = "linux")]
 use ngdp_cache::ribbit::RibbitCache;
+#[cfg(target_os = "linux")]
 use tempfile::TempDir;
 
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_ribbit_cache_directory_structure() -> Result<(), Box<dyn std::error::Error>> {
     // Use a temporary directory for testing
@@ -51,6 +54,7 @@ async fn test_ribbit_cache_directory_structure() -> Result<(), Box<dyn std::erro
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_ribbit_cache_file_naming() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;


### PR DESCRIPTION
Fixes for path tests:

* Test paths with `Path::ends_with` rather than converting to a `String`, so it works on platforms with ridiculous backward directory separators
* Disable tests that use `XDG_CACHE_HOME` on non-Linux platforms
