### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-cache"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "criterion",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/ngdp-cache/CHANGELOG.md
+++ b/ngdp-cache/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.3...ngdp-cache-v0.1.4) - 2025-07-18
+
+### Fixed
+
+- path tests on non-linux platforms
+
+### Other
+
+- Merge pull request #10 from micolous/fix/non-linux-paths
+
 ## [0.1.3](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.2...ngdp-cache-v0.1.3) - 2025-07-15
 
 ### Other

--- a/ngdp-cache/Cargo.toml
+++ b/ngdp-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-cache"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/ngdp-client/CHANGELOG.md
+++ b/ngdp-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.2.0...ngdp-client-v0.2.1) - 2025-07-18
+
+### Other
+
+- updated the following local packages: ngdp-cache
+
 ## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.1.2...ngdp-client-v0.2.0) - 2025-07-15
 
 ### Other

--- a/ngdp-client/Cargo.toml
+++ b/ngdp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-client"
-version = "0.2.0"
+version = "0.2.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -26,7 +26,7 @@ owo-colors = { version = "4.2.1", features = ["supports-colors"] }
 ribbit-client = { path = "../ribbit-client", version = "0.1.2" }
 tact-client = { path = "../tact-client", version = "0.1.2" }
 ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.2" }
-ngdp-cache = { path = "../ngdp-cache", version = "0.1.3" }
+ngdp-cache = { path = "../ngdp-cache", version = "0.1.4" }
 ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.1" }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true

--- a/tact-parser/CHANGELOG.md
+++ b/tact-parser/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/wowemulation-dev/cascette-rs/releases/tag/tact-parser-v0.1.0) - 2025-07-18
+
+### Fixed
+
+- clippy/fmt
+
+### Other
+
+- Move tact-parser dependencies into workspace
+- fmt
+- tidy up old stuff
+- Implement support for pre-8.2 roots
+- Use bufread to improve performance
+- Docs
+- fmt
+- Move all the tests into separate files like the rest of the packages
+- Sort ReadInt implementations
+- Initial wow TACT root parser


### PR DESCRIPTION



## 🤖 New release

* `ngdp-cache`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `tact-parser`: 0.1.0
* `ngdp-client`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `ngdp-cache`

<blockquote>

## [0.1.4](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.3...ngdp-cache-v0.1.4) - 2025-07-18

### Fixed

- path tests on non-linux platforms

### Other

- Merge pull request #10 from micolous/fix/non-linux-paths
</blockquote>

## `tact-parser`

<blockquote>

## [0.1.0](https://github.com/wowemulation-dev/cascette-rs/releases/tag/tact-parser-v0.1.0) - 2025-07-18

### Fixed

- clippy/fmt

### Other

- Move tact-parser dependencies into workspace
- fmt
- tidy up old stuff
- Implement support for pre-8.2 roots
- Use bufread to improve performance
- Docs
- fmt
- Move all the tests into separate files like the rest of the packages
- Sort ReadInt implementations
- Initial wow TACT root parser
</blockquote>

## `ngdp-client`

<blockquote>

## [0.2.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.2.0...ngdp-client-v0.2.1) - 2025-07-18

### Other

- updated the following local packages: ngdp-cache
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).