### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-cache"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "criterion",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "ribbit-client"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "asn1",
  "base64",

--- a/ngdp-cache/CHANGELOG.md
+++ b/ngdp-cache/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.3...ngdp-cache-v0.1.4) - 2025-07-18
+
+### Fixed
+
+- path tests on non-linux platforms
+
+### Other
+
+- Merge pull request #11 from micolous/refactor/bpsv-response
+- Merge pull request #10 from micolous/fix/non-linux-paths
+
 ## [0.1.3](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.2...ngdp-cache-v0.1.3) - 2025-07-15
 
 ### Other

--- a/ngdp-cache/Cargo.toml
+++ b/ngdp-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-cache"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -17,7 +17,7 @@ dirs = { workspace = true }
 futures = "0.3"
 ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.1" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-ribbit-client = { path = "../ribbit-client", version = "0.1.2" }
+ribbit-client = { path = "../ribbit-client", version = "0.2.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
 tact-client = { path = "../tact-client", version = "0.1.2" }

--- a/ngdp-client/CHANGELOG.md
+++ b/ngdp-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.2.0...ngdp-client-v0.2.1) - 2025-07-18
+
+### Other
+
+- updated the following local packages: ribbit-client, ngdp-cache
+
 ## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.1.2...ngdp-client-v0.2.0) - 2025-07-15
 
 ### Other

--- a/ngdp-client/Cargo.toml
+++ b/ngdp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-client"
-version = "0.2.0"
+version = "0.2.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -23,10 +23,10 @@ path = "src/main.rs"
 clap = { workspace = true, features = ["derive", "cargo", "env"] }
 comfy-table = "7.1.1"
 owo-colors = { version = "4.2.1", features = ["supports-colors"] }
-ribbit-client = { path = "../ribbit-client", version = "0.1.2" }
+ribbit-client = { path = "../ribbit-client", version = "0.2.0" }
 tact-client = { path = "../tact-client", version = "0.1.2" }
 ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.2" }
-ngdp-cache = { path = "../ngdp-cache", version = "0.1.3" }
+ngdp-cache = { path = "../ngdp-cache", version = "0.1.4" }
 ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.1" }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true

--- a/ribbit-client/CHANGELOG.md
+++ b/ribbit-client/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.1.2...ribbit-client-v0.2.0) - 2025-07-18
+
+### Other
+
+- Merge pull request #11 from micolous/refactor/bpsv-response
+- re-export TypedBpsvResponse
+- Allow non-BPSV responses to be parsed
+
 ## [0.1.2](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.1.1...ribbit-client-v0.1.2) - 2025-07-15
 
 ### Other

--- a/ribbit-client/Cargo.toml
+++ b/ribbit-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ribbit-client"
-version = "0.1.2"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/tact-parser/CHANGELOG.md
+++ b/tact-parser/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/wowemulation-dev/cascette-rs/releases/tag/tact-parser-v0.1.0) - 2025-07-18
+
+### Fixed
+
+- clippy/fmt
+
+### Other
+
+- Move tact-parser dependencies into workspace
+- fmt
+- tidy up old stuff
+- Implement support for pre-8.2 roots
+- Use bufread to improve performance
+- Docs
+- fmt
+- Move all the tests into separate files like the rest of the packages
+- Sort ReadInt implementations
+- Initial wow TACT root parser


### PR DESCRIPTION



## 🤖 New release

* `ribbit-client`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `ngdp-cache`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `tact-parser`: 0.1.0
* `ngdp-client`: 0.2.0 -> 0.2.1

### ⚠ `ribbit-client` breaking changes

```text
--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_missing.ron

Failed in:
  method from_bpsv of trait TypedResponse, previously in file /tmp/.tmpV1IQEC/ribbit-client/src/response_types.rs:15
  method from_bpsv of trait TypedResponse, previously in file /tmp/.tmpV1IQEC/ribbit-client/src/response_types.rs:15
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `ribbit-client`

<blockquote>

## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.1.2...ribbit-client-v0.2.0) - 2025-07-18

### Other

- Merge pull request #11 from micolous/refactor/bpsv-response
- re-export TypedBpsvResponse
- Allow non-BPSV responses to be parsed
</blockquote>

## `ngdp-cache`

<blockquote>

## [0.1.4](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.3...ngdp-cache-v0.1.4) - 2025-07-18

### Fixed

- path tests on non-linux platforms

### Other

- Merge pull request #11 from micolous/refactor/bpsv-response
- Merge pull request #10 from micolous/fix/non-linux-paths
</blockquote>

## `tact-parser`

<blockquote>

## [0.1.0](https://github.com/wowemulation-dev/cascette-rs/releases/tag/tact-parser-v0.1.0) - 2025-07-18

### Fixed

- clippy/fmt

### Other

- Move tact-parser dependencies into workspace
- fmt
- tidy up old stuff
- Implement support for pre-8.2 roots
- Use bufread to improve performance
- Docs
- fmt
- Move all the tests into separate files like the rest of the packages
- Sort ReadInt implementations
- Initial wow TACT root parser
</blockquote>

## `ngdp-client`

<blockquote>

## [0.2.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.2.0...ngdp-client-v0.2.1) - 2025-07-18

### Other

- updated the following local packages: ribbit-client, ngdp-cache
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).