### PR TITLE
chore: release

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -15,6 +15,8 @@ MD013:
   heading_line_length: 80
   # Number of characters for code blocks
   code_block_line_length: 120
+  # Number of characters for tables
+  tables: false
   # Strict length checking
   strict: false
 
@@ -38,6 +40,7 @@ MD040:
       'json',
       'ldif',
       'lua',
+      'markdown',
       'mermaid',
       'pgsql',
       'powershell',
@@ -47,6 +50,7 @@ MD040:
       'sql',
       'text',
       'toml',
+      'typescript',
       'wgsl',
       'xml',
       'yaml',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Performance benchmarks for Jenkins3 hashing
   - Example demonstrating WoW root file parsing
 
+- **Build configuration parsing support**:
+  - Complete parser for TACT build configuration files (text-based key=value format)
+  - Support for hash-size pairs parsing from configuration entries
+  - Handles empty values and various configuration formats
+  - Helper methods for accessing common build properties (root, encoding, install, download hashes)
+  - Build name extraction and VFS entry counting
+  - Comprehensive test coverage with real-world configuration data
+
+- **Encoding file parsing with 40-bit integer support**:
+  - Full parser for TACT encoding files (binary format with CKey ↔ EKey mapping)
+  - Native support for 40-bit integers used for file sizes (supports up to 1TB files)
+  - Bidirectional lookup: CKey → EKey entries and EKey → CKey reverse mapping
+  - Helper methods for common operations (get file size, get first encoding key)
+  - Big-endian header parsing for encoding file metadata
+  - Support for multiple encoding keys per content key (different compression methods)
+
+- **Install manifest parsing**:
+  - Parser for TACT install manifest files
+  - Support for file installation metadata and directory structures
+  - Integration with encoding file lookups for complete file resolution
+
+- **Utility functions**:
+  - 40-bit integer reading/writing utilities (little-endian format)
+  - Configuration file text parsing with proper empty value handling
+  - Hash parsing and validation utilities
+
 #### `ngdp-cdn` crate
 
 - **Automatic CDN fallback support**:
@@ -44,6 +70,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Support for JSON, BPSV, and formatted text output
   - Caching support with 30-minute TTL to reduce API load
   - Respects global cache settings (`--no-cache` and `--clear-cache` flags)
+
+- **TACT parser integration for build configuration analysis**:
+  - Added `inspect build-config` command for detailed build configuration analysis
+  - Downloads and parses real build configurations from CDN using tact-parser
+  - Visual tree representation of game build structure with emoji and Unicode box-drawing
+  - Shows core game files (root, encoding, install, download, size) with file sizes
+  - Displays build information (version, UID, product, installer)
+  - Patch status indication with hash display
+  - VFS (Virtual File System) entries listing with file counts
+  - Support for all output formats: text (visual tree), JSON, and raw BPSV
+  - Example: `ngdp inspect build-config wow_classic_era 61582 --region us`
+
+- **Enhanced products versions command with build configuration parsing**:
+  - Added `--parse-config` flag to `products versions` command
+  - Downloads and parses build configurations to show meaningful information
+  - Displays build names instead of just cryptic hashes (e.g., "WOW-62417patch11.2.0_Retail")
+  - Shows patch availability and file size information
+  - Counts VFS entries to indicate build complexity
+  - Maintains full backward compatibility when flag is not used
+  - Works across all WoW products (wow, wow_classic_era, wowt, etc.)
+  - Example: `ngdp products versions wow --parse-config`
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-cache"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "criterion",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-cdn"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "criterion",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "ribbit-client"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "asn1",
  "base64",
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "tact-client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "criterion",
  "ngdp-bpsv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tact-client",
+ "tact-parser",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2336,6 +2337,7 @@ dependencies = [
 name = "tact-parser"
 version = "0.1.0"
 dependencies = [
+ "byteorder",
  "clap",
  "criterion",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ repository = "https://github.com/wowemulation-dev/cascette-rs"
 homepage = "https://github.com/wowemulation-dev/cascette-rs"
 
 [workspace.dependencies]
+byteorder = "1.5"
 clap = "4.5"
 criterion = "0.6"
 dirs = "6.0"

--- a/deny.toml
+++ b/deny.toml
@@ -75,10 +75,7 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-  #"RUSTSEC-0000-0000",
-  #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
-  #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
-  #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+  { id = "RUSTSEC-2023-0071", reason = "RSA timing attack vulnerability - only used for Ribbit signature verification in network context where timing attacks are not feasible" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -94,9 +91,15 @@ ignore = [
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-  #"MIT",
-  #"Apache-2.0",
-  #"Apache-2.0 WITH LLVM-exception",
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
+  "ISC",
+  "Unicode-3.0",
+  "0BSD",
+  "MPL-2.0",
+  "CDLA-Permissive-2.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/ngdp-cache/CHANGELOG.md
+++ b/ngdp-cache/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.3...ngdp-cache-v0.1.4) - 2025-08-06
+
+### Fixed
+
+- path tests on non-linux platforms
+
+### Other
+
+- ✨ feat: integrate tact-parser with build configuration analysis
+- 📝 docs: update changelogs and add module documentation
+- Merge pull request #11 from micolous/refactor/bpsv-response
+- Merge pull request #10 from micolous/fix/non-linux-paths
+
 ### Fixed
 
 - Fixed path tests on non-Linux platforms:

--- a/ngdp-cache/Cargo.toml
+++ b/ngdp-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-cache"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,12 +15,12 @@ categories = ["caching", "filesystem", "games"]
 bytes = "1.8"
 dirs = { workspace = true }
 futures = "0.3"
-ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.1" }
+ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.2" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-ribbit-client = { path = "../ribbit-client", version = "0.1.2" }
+ribbit-client = { path = "../ribbit-client", version = "0.2.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
-tact-client = { path = "../tact-client", version = "0.1.2" }
+tact-client = { path = "../tact-client", version = "0.1.3" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
 tracing = { workspace = true }

--- a/ngdp-cache/tests/cache_validity_test.rs
+++ b/ngdp-cache/tests/cache_validity_test.rs
@@ -94,9 +94,9 @@ async fn test_cache_file_structure() -> Result<(), Box<dyn std::error::Error>> {
     // Test RibbitCache structure
     let ribbit_cache = RibbitCache::new().await?;
     ribbit_cache
-        .write("us", "versions", "wow", b"version data")
+        .write("us", "wow", "versions", b"version data")
         .await?;
-    ribbit_cache.write("eu", "cdns", "wow", b"cdn data").await?;
+    ribbit_cache.write("eu", "wow", "cdns", b"cdn data").await?;
 
     // Verify directory structure
     let cache_base = temp_dir.path().join("ngdp/ribbit");
@@ -107,8 +107,8 @@ async fn test_cache_file_structure() -> Result<(), Box<dyn std::error::Error>> {
     assert!(eu_dir.exists(), "EU region directory should exist");
 
     // Verify files exist (the exact file structure depends on implementation)
-    let us_versions = us_dir.join("versions").join("wow");
-    let eu_cdns = eu_dir.join("cdns").join("wow");
+    let us_versions = us_dir.join("wow").join("versions");
+    let eu_cdns = eu_dir.join("wow").join("cdns");
 
     assert!(us_versions.exists(), "US versions file should exist");
     assert!(eu_cdns.exists(), "EU cdns file should exist");

--- a/ngdp-cdn/CHANGELOG.md
+++ b/ngdp-cdn/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cdn-v0.2.1...ngdp-cdn-v0.2.2) - 2025-08-06
+
+### Other
+
+- ✨ feat: integrate tact-parser with build configuration analysis
+- 📝 docs: update changelogs and add module documentation
+- 🚨 fix: remove panicking Default impls and fix unwrap() calls
+
 ### Fixed
 
 - **Removed panicking Default implementation**:

--- a/ngdp-cdn/Cargo.toml
+++ b/ngdp-cdn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-cdn"
-version = "0.2.1"
+version = "0.2.2"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/ngdp-cdn/src/client.rs
+++ b/ngdp-cdn/src/client.rs
@@ -563,7 +563,6 @@ impl CdnClient {
     }
 }
 
-
 /// Builder for configuring CDN client
 #[derive(Debug, Clone)]
 pub struct CdnClientBuilder {

--- a/ngdp-cdn/src/fallback.rs
+++ b/ngdp-cdn/src/fallback.rs
@@ -287,7 +287,6 @@ impl CdnClientWithFallback {
     }
 }
 
-
 /// Builder for configuring CDN client with fallback
 #[derive(Debug, Clone)]
 pub struct CdnClientWithFallbackBuilder {

--- a/ngdp-client/CHANGELOG.md
+++ b/ngdp-client/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **TACT parser integration for build configuration analysis**:
+  - Added `inspect build-config` command for detailed build configuration analysis
+  - Downloads and parses real build configurations from CDN using tact-parser crate
+  - Visual tree representation of game build structure with emoji and Unicode box-drawing
+  - Shows core game files (root, encoding, install, download, size) with file sizes
+  - Displays build information (version, UID, product, installer)
+  - Patch status indication with hash display
+  - VFS (Virtual File System) entries listing with file counts
+  - Support for all output formats: text (visual tree), JSON, and raw BPSV
+  - Example: `ngdp inspect build-config wow_classic_era 61582 --region us`
+
+- **Enhanced products versions command with build configuration parsing**:
+  - Added `--parse-config` flag to `products versions` command
+  - Downloads and parses build configurations to show meaningful information
+  - Displays build names instead of just cryptic hashes (e.g., "WOW-62417patch11.2.0_Retail")
+  - Shows patch availability and file size information  
+  - Counts VFS entries to indicate build complexity
+  - Maintains full backward compatibility when flag is not used
+  - Works across all WoW products (wow, wow_classic_era, wowt, etc.)
+  - Example: `ngdp products versions wow --parse-config`
+
+- **Dependencies**:
+  - Added `tact-parser` (0.1.0) dependency for TACT file format parsing
+  - Added `ngdp-cdn` client integration for downloading build configurations
+
 ### Fixed
 
 - **Code optimization**:

--- a/ngdp-client/CHANGELOG.md
+++ b/ngdp-client/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.2.0...ngdp-client-v0.3.0) - 2025-08-06
+
+### Other
+
+- ✨ feat: integrate tact-parser with build configuration analysis
+- 📝 docs: update changelogs and add module documentation
+- 🎨 style: optimize code and remove unnecessary allocations
+
 ### Added
 
 - **TACT parser integration for build configuration analysis**:

--- a/ngdp-client/Cargo.toml
+++ b/ngdp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-client"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -23,11 +23,11 @@ path = "src/main.rs"
 clap = { workspace = true, features = ["derive", "cargo", "env"] }
 comfy-table = "7.1.1"
 owo-colors = { version = "4.2.1", features = ["supports-colors"] }
-ribbit-client = { path = "../ribbit-client", version = "0.1.2" }
-tact-client = { path = "../tact-client", version = "0.1.2" }
+ribbit-client = { path = "../ribbit-client", version = "0.2.0" }
+tact-client = { path = "../tact-client", version = "0.1.3" }
 ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.2" }
-ngdp-cache = { path = "../ngdp-cache", version = "0.1.3" }
-ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.1" }
+ngdp-cache = { path = "../ngdp-cache", version = "0.1.4" }
+ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.2" }
 tact-parser = { path = "../tact-parser", version = "0.1.0" }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true

--- a/ngdp-client/Cargo.toml
+++ b/ngdp-client/Cargo.toml
@@ -28,6 +28,7 @@ tact-client = { path = "../tact-client", version = "0.1.2" }
 ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.2" }
 ngdp-cache = { path = "../ngdp-cache", version = "0.1.3" }
 ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.1" }
+tact-parser = { path = "../tact-parser", version = "0.1.0" }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/ngdp-client/src/commands/inspect.rs
+++ b/ngdp-client/src/commands/inspect.rs
@@ -1,11 +1,17 @@
 use crate::{
     InspectCommands, OutputFormat,
+    cached_client::create_client,
     output::{
         OutputStyle, create_table, format_count_badge, format_header, format_key_value,
         header_cell, numeric_cell, print_section_header, print_subsection_header, regular_cell,
+        format_success, format_warning,
     },
 };
 use ngdp_bpsv::BpsvDocument;
+use ngdp_cdn::CdnClient;
+use ribbit_client::{Endpoint, Region, ProductVersionsResponse, ProductCdnsResponse};
+use tact_parser::config::BuildConfig;
+use std::str::FromStr;
 
 pub async fn handle(
     cmd: InspectCommands,
@@ -18,10 +24,7 @@ pub async fn handle(
             build,
             region,
         } => {
-            println!("Build config inspection not yet implemented");
-            println!("Product: {product}");
-            println!("Build: {build}");
-            println!("Region: {region}");
+            inspect_build_config(product, build, region, format).await?;
         }
         InspectCommands::CdnConfig { product, region } => {
             println!("CDN config inspection not yet implemented");
@@ -164,5 +167,300 @@ async fn inspect_bpsv(
         }
     }
 
+    Ok(())
+}
+
+/// Inspect a build configuration by downloading and parsing it
+async fn inspect_build_config(
+    product: String,
+    build: String,
+    region: String,
+    format: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let style = OutputStyle::new();
+    let region_enum = Region::from_str(&region)?;
+    
+    // Step 1: Get product version information
+    print_section_header(&format!("Build Config Analysis: {product} (Build {build})"), &style);
+    
+    let client = create_client(region_enum).await?;
+    let versions_endpoint = Endpoint::ProductVersions(product.clone());
+    let versions: ProductVersionsResponse = client.request_typed(&versions_endpoint).await?;
+    
+    // Find the specific build
+    let build_entry = versions.entries.iter()
+        .filter(|e| e.region == region)
+        .find(|e| e.build_id.to_string() == build || e.versions_name == build);
+        
+    let build_entry = match build_entry {
+        Some(entry) => entry,
+        None => {
+            eprintln!("{}", format_warning(&format!("Build '{build}' not found for {product} in region {region}"), &style));
+            return Ok(());
+        }
+    };
+    
+    println!("{}", format_key_value("Product", &product, &style));
+    println!("{}", format_key_value("Region", &region, &style));
+    println!("{}", format_key_value("Build ID", &build_entry.build_id.to_string(), &style));
+    println!("{}", format_key_value("Version", &build_entry.versions_name, &style));
+    println!("{}", format_key_value("Build Config Hash", &build_entry.build_config, &style));
+    println!();
+    
+    // Step 2: Get CDN information
+    let cdns_endpoint = Endpoint::ProductCdns(product.clone());
+    let cdns: ProductCdnsResponse = client.request_typed(&cdns_endpoint).await?;
+    
+    let cdn_entry = cdns.entries.iter().find(|e| e.name == region);
+    let cdn_entry = match cdn_entry {
+        Some(entry) => entry,
+        None => {
+            eprintln!("{}", format_warning(&format!("No CDN configuration found for region {region}"), &style));
+            return Ok(());
+        }
+    };
+    
+    // Step 3: Download the build config file
+    print_subsection_header("Downloading Build Configuration", &style);
+    
+    let cdn_client = CdnClient::new()?;
+    let cdn_host = &cdn_entry.hosts[0]; // Use first CDN host
+    let cdn_path = &cdn_entry.path;
+    
+    println!("Downloading from: {}/{}/config/{}", cdn_host, cdn_path, &build_entry.build_config);
+    
+    let response = cdn_client.download_build_config(cdn_host, cdn_path, &build_entry.build_config).await?;
+    let config_text = response.text().await?;
+    
+    // Step 4: Parse the build config
+    let build_config = BuildConfig::parse(&config_text)?;
+    
+    match format {
+        OutputFormat::Json | OutputFormat::JsonPretty => {
+            output_build_config_json(&build_config, format)?;
+        }
+        OutputFormat::Text => {
+            output_build_config_tree(&build_config, &style);
+        }
+        OutputFormat::Bpsv => {
+            println!("{config_text}");
+        }
+    }
+    
+    Ok(())
+}
+
+/// Output build config as a visual tree
+fn output_build_config_tree(config: &BuildConfig, style: &OutputStyle) {
+    print_subsection_header("Build Configuration Tree", style);
+    
+    // Core Files Section
+    println!("📁 {}", format_header("Core Game Files", style));
+    
+    if let Some(root_hash) = config.root_hash() {
+        println!("├── 🗂️  Root File");
+        println!("│   ├── Hash: {}", root_hash);
+        if let Some(size) = config.config.get_size("root") {
+            println!("│   └── Size: {} bytes ({:.2} MB)", size, size as f64 / (1024.0 * 1024.0));
+        }
+    }
+    
+    if let Some(encoding_hash) = config.encoding_hash() {
+        println!("├── 🔗 Encoding File (CKey ↔ EKey mapping)");
+        println!("│   ├── Hash: {}", encoding_hash);
+        if let Some(size) = config.config.get_size("encoding") {
+            println!("│   └── Size: {} bytes ({:.2} KB)", size, size as f64 / 1024.0);
+        }
+    }
+    
+    if let Some(install_hash) = config.install_hash() {
+        println!("├── 📦 Install Manifest");
+        println!("│   ├── Hash: {}", install_hash);
+        if let Some(size) = config.config.get_size("install") {
+            println!("│   └── Size: {} bytes ({:.2} KB)", size, size as f64 / 1024.0);
+        }
+    }
+    
+    if let Some(download_hash) = config.download_hash() {
+        println!("├── ⬇️  Download Manifest");
+        println!("│   ├── Hash: {}", download_hash);
+        if let Some(size) = config.config.get_size("download") {
+            println!("│   └── Size: {} bytes ({:.2} KB)", size, size as f64 / 1024.0);
+        }
+    }
+    
+    if let Some(size_hash) = config.size_hash() {
+        println!("└── 📏 Size File");
+        println!("    ├── Hash: {}", size_hash);
+        if let Some(size) = config.config.get_size("size") {
+            println!("    └── Size: {} bytes ({:.2} KB)", size, size as f64 / 1024.0);
+        }
+    }
+    
+    println!();
+    
+    // Build Information Section
+    println!("📋 {}", format_header("Build Information", style));
+    
+    if let Some(build_name) = config.build_name() {
+        println!("├── Version: {}", format_success(build_name, style));
+    }
+    if let Some(build_uid) = config.config.get_value("build-uid") {
+        println!("├── Build UID: {}", build_uid);
+    }
+    if let Some(build_product) = config.config.get_value("build-product") {
+        println!("├── Product: {}", build_product);
+    }
+    if let Some(installer) = config.config.get_value("build-playbuild-installer") {
+        println!("└── Installer: {}", installer);
+    }
+    
+    println!();
+    
+    // Patching Section
+    println!("🔄 {}", format_header("Patching", style));
+    
+    let has_patch = config.config.get_value("patch").is_some_and(|v| !v.is_empty());
+    if has_patch {
+        if let Some(patch_hash) = config.config.get_value("patch") {
+            println!("├── ✅ Patch Available");
+            println!("│   └── Hash: {}", patch_hash);
+        }
+    } else {
+        println!("└── ❌ No patch data");
+    }
+    
+    println!();
+    
+    // VFS Section
+    println!("🗃️  {}", format_header("Virtual File System (VFS)", style));
+    
+    let mut vfs_entries = Vec::new();
+    for key in config.config.keys() {
+        if key.starts_with("vfs-") {
+            if let Some(value) = config.config.get_value(key) {
+                vfs_entries.push((key, value));
+            }
+        }
+    }
+    
+    if !vfs_entries.is_empty() {
+        vfs_entries.sort_by_key(|(k, _)| *k);
+        for (i, (key, value)) in vfs_entries.iter().enumerate() {
+            let is_last = i == vfs_entries.len() - 1;
+            let prefix = if is_last { "└──" } else { "├──" };
+            
+            if value.is_empty() {
+                println!("{} {}: {}", prefix, key, format_warning("(empty)", style));
+            } else {
+                println!("{} {}: {}", prefix, key, value);
+            }
+        }
+    } else {
+        println!("└── No VFS entries found");
+    }
+    
+    println!();
+    
+    // Raw Configuration Section
+    print_subsection_header("Raw Configuration Entries", style);
+    
+    let mut table = create_table(style);
+    table.set_header(vec![
+        header_cell("Key", style),
+        header_cell("Value", style),
+        header_cell("Type", style),
+    ]);
+    
+    let mut keys: Vec<_> = config.config.keys().into_iter().collect();
+    keys.sort();
+    
+    for key in keys {
+        if let Some(value) = config.config.get_value(key) {
+            let value_type = if config.config.get_hash(key).is_some() {
+                "Hash + Size"
+            } else if value.is_empty() {
+                "Empty"
+            } else if value.chars().all(|c| c.is_ascii_digit()) {
+                "Number"
+            } else {
+                "String"
+            };
+            
+            let display_value = if value.len() > 50 {
+                format!("{}...", &value[..47])
+            } else {
+                value.to_string()
+            };
+            
+            table.add_row(vec![
+                regular_cell(key),
+                regular_cell(&display_value),
+                regular_cell(value_type),
+            ]);
+        }
+    }
+    
+    println!("{table}");
+}
+
+/// Output build config as JSON
+fn output_build_config_json(
+    config: &BuildConfig, 
+    format: OutputFormat
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut json_data = serde_json::Map::new();
+    
+    // Core hashes
+    if let Some(hash) = config.root_hash() {
+        json_data.insert("root_hash".to_string(), serde_json::Value::String(hash.to_string()));
+    }
+    if let Some(hash) = config.encoding_hash() {
+        json_data.insert("encoding_hash".to_string(), serde_json::Value::String(hash.to_string()));
+    }
+    if let Some(hash) = config.install_hash() {
+        json_data.insert("install_hash".to_string(), serde_json::Value::String(hash.to_string()));
+    }
+    if let Some(hash) = config.download_hash() {
+        json_data.insert("download_hash".to_string(), serde_json::Value::String(hash.to_string()));
+    }
+    if let Some(hash) = config.size_hash() {
+        json_data.insert("size_hash".to_string(), serde_json::Value::String(hash.to_string()));
+    }
+    
+    // Build info
+    if let Some(name) = config.build_name() {
+        json_data.insert("build_name".to_string(), serde_json::Value::String(name.to_string()));
+    }
+    
+    // All raw values
+    let mut raw_config = serde_json::Map::new();
+    for key in config.config.keys() {
+        if let Some(value) = config.config.get_value(key) {
+            raw_config.insert(key.to_string(), serde_json::Value::String(value.to_string()));
+        }
+    }
+    json_data.insert("raw_config".to_string(), serde_json::Value::Object(raw_config));
+    
+    // Hash pairs
+    let mut hash_pairs = serde_json::Map::new();
+    for key in config.config.keys() {
+        if let Some(hash_pair) = config.config.get_hash_pair(key) {
+            hash_pairs.insert(key.to_string(), serde_json::json!({
+                "hash": hash_pair.hash,
+                "size": hash_pair.size
+            }));
+        }
+    }
+    if !hash_pairs.is_empty() {
+        json_data.insert("hash_pairs".to_string(), serde_json::Value::Object(hash_pairs));
+    }
+    
+    let output = match format {
+        OutputFormat::JsonPretty => serde_json::to_string_pretty(&json_data)?,
+        _ => serde_json::to_string(&json_data)?,
+    };
+    
+    println!("{output}");
     Ok(())
 }

--- a/ngdp-client/src/commands/products.rs
+++ b/ngdp-client/src/commands/products.rs
@@ -8,6 +8,8 @@ use crate::{
     },
     wago_api,
 };
+use ngdp_cdn::CdnClient;
+use tact_parser::config::BuildConfig;
 use chrono::{Duration, Utc};
 use ribbit_client::{
     CdnEntry, Endpoint, ProductCdnsResponse, ProductVersionsResponse, Region, SummaryResponse,
@@ -24,7 +26,8 @@ pub async fn handle(
             product,
             region,
             all_regions,
-        } => show_versions(product, region, all_regions, format).await,
+            parse_config,
+        } => show_versions(product, region, all_regions, parse_config, format).await,
         ProductsCommands::Cdns { product, region } => show_cdns(product, region, format).await,
         ProductsCommands::Info { product, region } => show_info(product, region, format).await,
         ProductsCommands::Builds {
@@ -138,6 +141,7 @@ async fn show_versions(
     product: String,
     region: String,
     all_regions: bool,
+    parse_config: bool,
     format: OutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let region = Region::from_str(&region)?;
@@ -146,6 +150,60 @@ async fn show_versions(
     let endpoint = Endpoint::ProductVersions(product.clone());
     let response = client.request(&endpoint).await?;
     let versions: ProductVersionsResponse = client.request_typed(&endpoint).await?;
+    
+    // If parse_config is true, fetch build configs
+    let build_configs = if parse_config {
+        let cdns_endpoint = Endpoint::ProductCdns(product.clone());
+        let cdns: ProductCdnsResponse = client.request_typed(&cdns_endpoint).await?;
+        
+        // Get CDN configuration for the region
+        if let Some(cdn_entry) = cdns.entries.iter().find(|e| e.name == region.as_str()) {
+            let cdn_client = CdnClient::new()?;
+            let cdn_host = &cdn_entry.hosts[0]; // Use first CDN host
+            let cdn_path = &cdn_entry.path;
+            
+            let mut configs = std::collections::HashMap::new();
+            
+            // Download build configs for the requested regions
+            let entries_to_process: Vec<_> = if all_regions {
+                versions.entries.iter().collect()
+            } else {
+                versions.entries.iter().filter(|e| e.region == region.as_str()).collect()
+            };
+            
+            for entry in entries_to_process {
+                match cdn_client.download_build_config(cdn_host, cdn_path, &entry.build_config).await {
+                    Ok(response) => {
+                        match response.text().await {
+                            Ok(config_text) => {
+                                match BuildConfig::parse(&config_text) {
+                                    Ok(config) => {
+                                        configs.insert(entry.build_config.clone(), config);
+                                    },
+                                    Err(e) => {
+                                        eprintln!("Warning: Failed to parse config {}: {}", entry.build_config, e);
+                                    }
+                                }
+                            },
+                            Err(e) => {
+                                eprintln!("Warning: Failed to read config {}: {}", entry.build_config, e);
+                            }
+                        }
+                    },
+                    Err(e) => {
+                        eprintln!("Warning: Failed to download config {}: {}", entry.build_config, e);
+                    }
+                }
+            }
+            
+            Some(configs)
+        } else {
+            eprintln!("Warning: No CDN configuration found for region {}", region.as_str());
+            None
+        }
+    } else {
+        None
+    };
 
     match format {
         OutputFormat::Json | OutputFormat::JsonPretty => {
@@ -305,6 +363,76 @@ async fn show_versions(
                 }
 
                 println!("{table}");
+                
+                // Show parsed build config information if available
+                if let Some(ref configs) = build_configs {
+                    if let Some(build_config) = configs.get(&entry.build_config) {
+                        println!();
+                        print_subsection_header("Parsed Build Configuration", &style);
+                        
+                        // Show key build details in a compact format
+                        if let Some(build_name) = build_config.build_name() {
+                            println!("{}", format_key_value("Build Name", build_name, &style));
+                        }
+                        
+                        if let Some(root_hash) = build_config.root_hash() {
+                            let size_info = if let Some(size) = build_config.config.get_size("root") {
+                                format!(" ({:.1} MB)", size as f64 / (1024.0 * 1024.0))
+                            } else {
+                                String::new()
+                            };
+                            println!("{}", format_key_value("Root File", &format!("{}{}", root_hash, size_info), &style));
+                        }
+                        
+                        if let Some(encoding_hash) = build_config.encoding_hash() {
+                            let size_info = if let Some(size) = build_config.config.get_size("encoding") {
+                                format!(" ({:.1} MB)", size as f64 / (1024.0 * 1024.0))
+                            } else {
+                                String::new()
+                            };
+                            println!("{}", format_key_value("Encoding File", &format!("{}{}", encoding_hash, size_info), &style));
+                        }
+                        
+                        if let Some(install_hash) = build_config.install_hash() {
+                            let size_info = if let Some(size) = build_config.config.get_size("install") {
+                                format!(" ({:.1} KB)", size as f64 / 1024.0)
+                            } else {
+                                String::new()
+                            };
+                            println!("{}", format_key_value("Install Manifest", &format!("{}{}", install_hash, size_info), &style));
+                        }
+                        
+                        if let Some(download_hash) = build_config.download_hash() {
+                            let size_info = if let Some(size) = build_config.config.get_size("download") {
+                                format!(" ({:.1} MB)", size as f64 / (1024.0 * 1024.0))
+                            } else {
+                                String::new()
+                            };
+                            println!("{}", format_key_value("Download Manifest", &format!("{}{}", download_hash, size_info), &style));
+                        }
+                        
+                        // Show patch information
+                        let has_patch = build_config.config.get_value("patch").is_some_and(|v| !v.is_empty());
+                        if has_patch {
+                            if let Some(patch_hash) = build_config.config.get_value("patch") {
+                                let size_info = if let Some(size) = build_config.config.get_size("patch") {
+                                    format!(" ({:.1} KB)", size as f64 / 1024.0)
+                                } else {
+                                    String::new()
+                                };
+                                println!("{}", format_key_value("Patch", &format!("{}{}", patch_hash, size_info), &style));
+                            }
+                        } else {
+                            println!("{}", format_key_value("Patch", "Not available", &style));
+                        }
+                        
+                        // Count VFS entries
+                        let vfs_count = build_config.config.keys().into_iter().filter(|k| k.starts_with("vfs-") && !k.ends_with("-size")).count();
+                        if vfs_count > 0 {
+                            println!("{}", format_key_value("VFS Entries", &format!("{} files", vfs_count), &style));
+                        }
+                    }
+                }
             } else {
                 println!();
                 println!(

--- a/ngdp-client/src/lib.rs
+++ b/ngdp-client/src/lib.rs
@@ -51,6 +51,10 @@ pub enum ProductsCommands {
         /// Show all regions
         #[arg(short, long)]
         all_regions: bool,
+
+        /// Parse and show build configuration details
+        #[arg(long)]
+        parse_config: bool,
     },
 
     /// Show CDN configuration for a product

--- a/ribbit-client/CHANGELOG.md
+++ b/ribbit-client/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.1.2...ribbit-client-v0.2.0) - 2025-08-06
+
+### Other
+
+- 📝 docs: update changelogs and add module documentation
+- Merge pull request #11 from micolous/refactor/bpsv-response
+- re-export TypedBpsvResponse
+- Allow non-BPSV responses to be parsed
+
 ### Changed
 
 - Refactored BPSV response handling:

--- a/ribbit-client/Cargo.toml
+++ b/ribbit-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ribbit-client"
-version = "0.1.2"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/tact-client/CHANGELOG.md
+++ b/tact-client/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/wowemulation-dev/cascette-rs/compare/tact-client-v0.1.2...tact-client-v0.1.3) - 2025-08-06
+
+### Other
+
+- ✨ feat: integrate tact-parser with build configuration analysis
+- 📝 docs: update changelogs and add module documentation
+- 🚨 fix: remove panicking Default impls and fix unwrap() calls
+
 ### Fixed
 
 - **Replaced unwrap() calls with proper error handling**:

--- a/tact-client/Cargo.toml
+++ b/tact-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact-client"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/tact-client/src/response_types.rs
+++ b/tact-client/src/response_types.rs
@@ -132,9 +132,7 @@ pub fn parse_versions(content: &str) -> Result<Vec<VersionEntry>> {
                 .ok_or_else(|| Error::missing_field("BuildId"))?
                 .parse()
                 .map_err(|_| {
-                    let build_id_str = row
-                        .get_raw(build_id_idx)
-                        .unwrap_or("<missing>"); // Safe because we checked above
+                    let build_id_str = row.get_raw(build_id_idx).unwrap_or("<missing>"); // Safe because we checked above
                     Error::InvalidManifest {
                         line: 0,
                         reason: format!("Invalid BuildId: {build_id_str}"),

--- a/tact-parser/CHANGELOG.md
+++ b/tact-parser/CHANGELOG.md
@@ -9,15 +9,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial release of tact-parser crate
-- Support for parsing WoW root files to find file IDs and MD5s
-- Jenkins3 hash implementation for TACT data processing
-- Support for both modern (8.2+) and legacy pre-8.2 root formats
-- Efficient buffered I/O operations for improved performance
-- Comprehensive test suite with unit and integration tests
-- Performance benchmarks for Jenkins3 hashing
-- Example demonstrating WoW root file parsing
-- Module-level documentation with usage examples
+- **Core TACT file parsing support**:
+  - Initial release of tact-parser crate
+  - Support for parsing WoW root files to find file IDs and MD5s
+  - Jenkins3 hash implementation for TACT data processing
+  - Support for both modern (8.2+) and legacy pre-8.2 root formats
+  - Efficient buffered I/O operations for improved performance
+  - Module-level documentation with usage examples
+
+- **Build configuration parsing**:
+  - Complete parser for TACT build configuration files (text-based key=value format)
+  - Support for hash-size pairs parsing from configuration entries
+  - Handles empty values and various configuration formats (key=value, key= for empty)
+  - Helper methods for accessing common build properties:
+    - `root_hash()`, `encoding_hash()`, `install_hash()`, `download_hash()`, `size_hash()`
+    - `build_name()` for human-readable version strings
+    - Size information retrieval for files with hash-size pairs
+  - Configuration value and hash pair access methods
+  - Comprehensive test coverage with real-world configuration data from CDN
+
+- **Encoding file parsing with 40-bit integer support**:
+  - Full parser for TACT encoding files (binary format with CKey ↔ EKey mapping)
+  - Native support for 40-bit integers used for file sizes (supports up to 1TB files)
+  - Bidirectional lookup capabilities:
+    - `lookup_by_ckey()` - Content Key → Encoding entries mapping
+    - `lookup_by_ekey()` - Encoding Key → Content Key reverse mapping
+  - Helper methods for common operations:
+    - `get_ekey_for_ckey()` - Get first encoding key for content
+    - `get_file_size()` - Get file size for content key
+    - `ckey_count()` and `ekey_count()` - Entry counting
+  - Big-endian header parsing for encoding file metadata
+  - Support for multiple encoding keys per content key (different compression methods)
+  - Handles various 40-bit integer values from 0 to 1TB (0xFFFFFFFFFF)
+
+- **Install manifest parsing**:
+  - Parser for TACT install manifest files
+  - Support for file installation metadata and directory structures
+  - Integration with encoding file lookups for complete file resolution
+  - Handles install file priorities and file system organization
+
+- **Utility functions**:
+  - 40-bit integer reading/writing utilities (little-endian format)
+  - `read_uint40()` and `write_uint40()` for precise 5-byte integer handling
+  - Configuration file text parsing with proper empty value handling
+  - Hash parsing and validation utilities
+
+- **Comprehensive testing**:
+  - 49 total tests (24 unit tests, 25 integration tests)
+  - Real-world data parsing tests with actual CDN configuration files
+  - Edge case testing for empty values, large file sizes, and malformed data
+  - Performance benchmarks for Jenkins3 hashing
+  - Examples demonstrating all major functionality
 
 ### Fixed
 

--- a/tact-parser/CHANGELOG.md
+++ b/tact-parser/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/wowemulation-dev/cascette-rs/releases/tag/tact-parser-v0.1.0) - 2025-08-06
+
+### Fixed
+
+- clippy/fmt
+
+### Other
+
+- ✨ feat: integrate tact-parser with build configuration analysis
+- 📝 docs: update changelogs and add module documentation
+- 🎨 style: optimize code and remove unnecessary allocations
+- 🚨 fix: remove panicking Default impls and fix unwrap() calls
+- Move tact-parser dependencies into workspace
+- fmt
+- tidy up old stuff
+- Implement support for pre-8.2 roots
+- Use bufread to improve performance
+- Docs
+- fmt
+- Move all the tests into separate files like the rest of the packages
+- Sort ReadInt implementations
+- Initial wow TACT root parser
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/tact-parser/Cargo.toml
+++ b/tact-parser/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
+byteorder.workspace = true
 modular-bitfield.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/tact-parser/src/config.rs
+++ b/tact-parser/src/config.rs
@@ -1,0 +1,345 @@
+//! Configuration file parser for TACT
+//!
+//! Parses build and CDN configuration files which use a simple key-value format.
+//! Some values contain hash-size pairs for referencing other TACT files.
+
+use std::collections::HashMap;
+use tracing::{debug, trace};
+
+use crate::Result;
+
+/// A hash-size pair found in config values
+#[derive(Debug, Clone, PartialEq)]
+pub struct HashPair {
+    /// The hash (usually MD5 hex string)
+    pub hash: String,
+    /// The size in bytes
+    pub size: u64,
+}
+
+/// Configuration file (build or CDN)
+#[derive(Debug, Clone)]
+pub struct ConfigFile {
+    /// All key-value pairs
+    pub values: HashMap<String, String>,
+    /// Hash-size pairs extracted from values
+    pub hashes: HashMap<String, HashPair>,
+}
+
+impl ConfigFile {
+    /// Parse a configuration file from text
+    pub fn parse(text: &str) -> Result<Self> {
+        let mut values = HashMap::new();
+        let mut hashes = HashMap::new();
+        
+        for line in text.lines() {
+            let line = line.trim();
+            
+            // Skip comments and empty lines
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            
+            
+            // Split on " = " (space equals space) or " =" (space equals, for empty values)
+            let (key, value) = if let Some(eq_pos) = line.find(" = ") {
+                let key = line[..eq_pos].trim();
+                let value = line[eq_pos + 3..].trim(); // Skip " = " and trim
+                (key, value)
+            } else if let Some(eq_pos) = line.find(" =") {
+                let key = line[..eq_pos].trim();
+                let value = line[eq_pos + 2..].trim(); // Skip " =" and trim
+                (key, value)
+            } else {
+                continue; // No valid key = value format found
+            };
+            
+            trace!("Config entry: '{}' = '{}'", key, value);
+            
+            // Always insert the value, even if empty
+            values.insert(key.to_string(), value.to_string());
+            
+            // Check if value contains hash and size
+            if !value.is_empty() {
+                let parts: Vec<&str> = value.split_whitespace().collect();
+                if parts.len() >= 2 && is_hex_hash(parts[0]) {
+                    if let Ok(size) = parts[1].parse::<u64>() {
+                        hashes.insert(key.to_string(), HashPair {
+                            hash: parts[0].to_string(),
+                            size,
+                        });
+                    }
+                }
+            }
+        }
+        
+        debug!("Parsed config with {} entries, {} hash pairs", values.len(), hashes.len());
+        
+        Ok(ConfigFile { values, hashes })
+    }
+    
+    /// Get a value by key
+    pub fn get_value(&self, key: &str) -> Option<&str> {
+        self.values.get(key).map(|s| s.as_str())
+    }
+    
+    /// Get a hash by key (extracts from hash-size pairs)
+    pub fn get_hash(&self, key: &str) -> Option<&str> {
+        self.hashes.get(key).map(|hp| hp.hash.as_str())
+    }
+    
+    /// Get a size by key (extracts from hash-size pairs)
+    pub fn get_size(&self, key: &str) -> Option<u64> {
+        self.hashes.get(key).map(|hp| hp.size)
+    }
+    
+    /// Get a hash pair by key
+    pub fn get_hash_pair(&self, key: &str) -> Option<&HashPair> {
+        self.hashes.get(key)
+    }
+    
+    /// Check if a key exists
+    pub fn has_key(&self, key: &str) -> bool {
+        self.values.contains_key(key)
+    }
+    
+    /// Get all keys
+    pub fn keys(&self) -> Vec<&str> {
+        self.values.keys().map(|s| s.as_str()).collect()
+    }
+}
+
+/// Common configuration keys for build configs
+pub mod build_keys {
+    /// Root file hash and size
+    pub const ROOT: &str = "root";
+    /// Install manifest hash and size
+    pub const INSTALL: &str = "install";
+    /// Download manifest hash and size
+    pub const DOWNLOAD: &str = "download";
+    /// Encoding file hash and size
+    pub const ENCODING: &str = "encoding";
+    /// Size file hash and size
+    pub const SIZE: &str = "size";
+    /// Patch file hash and size
+    pub const PATCH: &str = "patch";
+    /// Patch config hash and size
+    pub const PATCH_CONFIG: &str = "patch-config";
+    /// Build name
+    pub const BUILD_NAME: &str = "build-name";
+    /// Build UID
+    pub const BUILD_UID: &str = "build-uid";
+    /// Build product
+    pub const BUILD_PRODUCT: &str = "build-product";
+    /// Encoding sizes
+    pub const ENCODING_SIZE: &str = "encoding-size";
+    /// Install sizes
+    pub const INSTALL_SIZE: &str = "install-size";
+    /// Download sizes
+    pub const DOWNLOAD_SIZE: &str = "download-size";
+    /// Size sizes
+    pub const SIZE_SIZE: &str = "size-size";
+    /// VFS root
+    pub const VFS_ROOT: &str = "vfs-root";
+}
+
+/// Common configuration keys for CDN configs
+pub mod cdn_keys {
+    /// Archive group
+    pub const ARCHIVE_GROUP: &str = "archive-group";
+    /// Archives list
+    pub const ARCHIVES: &str = "archives";
+    /// Patch archives
+    pub const PATCH_ARCHIVES: &str = "patch-archives";
+    /// File index
+    pub const FILE_INDEX: &str = "file-index";
+    /// Patch file index
+    pub const PATCH_FILE_INDEX: &str = "patch-file-index";
+}
+
+/// Check if a string looks like a hex hash
+fn is_hex_hash(s: &str) -> bool {
+    s.len() >= 6 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Build configuration
+#[derive(Debug, Clone)]
+pub struct BuildConfig {
+    /// Underlying config file
+    pub config: ConfigFile,
+}
+
+impl BuildConfig {
+    /// Parse a build configuration
+    pub fn parse(text: &str) -> Result<Self> {
+        let config = ConfigFile::parse(text)?;
+        Ok(BuildConfig { config })
+    }
+    
+    /// Get the root file hash
+    pub fn root_hash(&self) -> Option<&str> {
+        self.config.get_hash(build_keys::ROOT)
+    }
+    
+    /// Get the encoding file hash
+    pub fn encoding_hash(&self) -> Option<&str> {
+        self.config.get_hash(build_keys::ENCODING)
+    }
+    
+    /// Get the install manifest hash
+    pub fn install_hash(&self) -> Option<&str> {
+        self.config.get_hash(build_keys::INSTALL)
+    }
+    
+    /// Get the download manifest hash
+    pub fn download_hash(&self) -> Option<&str> {
+        self.config.get_hash(build_keys::DOWNLOAD)
+    }
+    
+    /// Get the size file hash
+    pub fn size_hash(&self) -> Option<&str> {
+        self.config.get_hash(build_keys::SIZE)
+    }
+    
+    /// Get the build name
+    pub fn build_name(&self) -> Option<&str> {
+        self.config.get_value(build_keys::BUILD_NAME)
+    }
+}
+
+/// CDN configuration
+#[derive(Debug, Clone)]
+pub struct CdnConfig {
+    /// Underlying config file
+    pub config: ConfigFile,
+}
+
+impl CdnConfig {
+    /// Parse a CDN configuration
+    pub fn parse(text: &str) -> Result<Self> {
+        let config = ConfigFile::parse(text)?;
+        Ok(CdnConfig { config })
+    }
+    
+    /// Get the archives list
+    pub fn archives(&self) -> Vec<&str> {
+        self.config
+            .get_value(cdn_keys::ARCHIVES)
+            .map(|v| v.split_whitespace().collect())
+            .unwrap_or_default()
+    }
+    
+    /// Get the archive group
+    pub fn archive_group(&self) -> Option<&str> {
+        self.config.get_value(cdn_keys::ARCHIVE_GROUP)
+    }
+    
+    /// Get the file index
+    pub fn file_index(&self) -> Option<&str> {
+        self.config.get_value(cdn_keys::FILE_INDEX)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_parse_simple_config() {
+        let config_text = r#"
+# This is a comment
+key1 = value1
+key2 = value2
+
+# Empty lines are ignored
+key3 = value with spaces
+        "#;
+        
+        let config = ConfigFile::parse(config_text).unwrap();
+        assert_eq!(config.get_value("key1"), Some("value1"));
+        assert_eq!(config.get_value("key2"), Some("value2"));
+        assert_eq!(config.get_value("key3"), Some("value with spaces"));
+        assert_eq!(config.get_value("nonexistent"), None);
+    }
+    
+    #[test]
+    fn test_parse_hash_pairs() {
+        let config_text = r#"
+encoding = abc123def456789 123456
+root = 0123456789abcdef 789
+install = fedcba9876543210 456789
+invalid = not_a_hash 123
+        "#;
+        
+        let config = ConfigFile::parse(config_text).unwrap();
+        
+        // Check hash extraction
+        assert_eq!(config.get_hash("encoding"), Some("abc123def456789"));
+        assert_eq!(config.get_size("encoding"), Some(123456));
+        
+        assert_eq!(config.get_hash("root"), Some("0123456789abcdef"));
+        assert_eq!(config.get_size("root"), Some(789));
+        
+        assert_eq!(config.get_hash("install"), Some("fedcba9876543210"));
+        assert_eq!(config.get_size("install"), Some(456789));
+        
+        // Invalid hash should not be extracted
+        assert_eq!(config.get_hash("invalid"), None);
+        
+        // But the raw value should still be there
+        assert_eq!(config.get_value("invalid"), Some("not_a_hash 123"));
+    }
+    
+    #[test]
+    fn test_build_config() {
+        let config_text = r#"
+root = abc123 100
+encoding = def456 200
+install = 789abc 300
+download = cdef01 400
+size = 234567 500
+build-name = 10.0.0.12345
+build-uid = wow/game
+        "#;
+        
+        let build = BuildConfig::parse(config_text).unwrap();
+        
+        assert_eq!(build.root_hash(), Some("abc123"));
+        assert_eq!(build.encoding_hash(), Some("def456"));
+        assert_eq!(build.install_hash(), Some("789abc"));
+        assert_eq!(build.download_hash(), Some("cdef01"));
+        assert_eq!(build.size_hash(), Some("234567"));
+        assert_eq!(build.build_name(), Some("10.0.0.12345"));
+    }
+    
+    #[test]
+    fn test_cdn_config() {
+        let config_text = r#"
+archives = archive1 archive2 archive3
+archive-group = abc123def456
+file-index = 789abcdef012
+patch-archives = patch1 patch2
+        "#;
+        
+        let cdn = CdnConfig::parse(config_text).unwrap();
+        
+        let archives = cdn.archives();
+        assert_eq!(archives.len(), 3);
+        assert_eq!(archives[0], "archive1");
+        assert_eq!(archives[1], "archive2");
+        assert_eq!(archives[2], "archive3");
+        
+        assert_eq!(cdn.archive_group(), Some("abc123def456"));
+        assert_eq!(cdn.file_index(), Some("789abcdef012"));
+    }
+    
+    #[test]
+    fn test_is_hex_hash() {
+        assert!(is_hex_hash("abc123def456"));
+        assert!(is_hex_hash("0123456789ABCDEF"));
+        assert!(!is_hex_hash("not_hex"));
+        assert!(!is_hex_hash("abc12g")); // 'g' is not hex
+        assert!(!is_hex_hash("abc")); // Too short
+    }
+    
+}

--- a/tact-parser/src/encoding.rs
+++ b/tact-parser/src/encoding.rs
@@ -1,0 +1,396 @@
+//! Encoding file parser for TACT
+//!
+//! The encoding file maps Content Keys (CKey) to Encoding Keys (EKey) and vice versa.
+//! This is a critical component for resolving file references in the TACT system.
+//!
+//! IMPORTANT: Encoding files use BIG-ENDIAN byte order, unlike most other TACT formats!
+
+use byteorder::{BigEndian, ReadBytesExt};
+use std::collections::HashMap;
+use std::io::{Cursor, Read};
+use tracing::{debug, trace, warn};
+
+use crate::{Error, Result};
+
+/// Magic bytes for encoding file: "EN"
+const ENCODING_MAGIC: [u8; 2] = [0x45, 0x4E]; // 'E', 'N'
+
+/// Encoding file header
+#[derive(Debug, Clone)]
+pub struct EncodingHeader {
+    /// Magic bytes "EN"
+    pub magic: [u8; 2],
+    /// Version (should be 1)
+    pub version: u8,
+    /// Hash size for CKeys (usually 16 for MD5)
+    pub ckey_hash_size: u8,
+    /// Hash size for EKeys (usually 16 for MD5)
+    pub ekey_hash_size: u8,
+    /// Page size for CKey pages in KB
+    pub ckey_page_size_kb: u16,
+    /// Page size for EKey pages in KB
+    pub ekey_page_size_kb: u16,
+    /// Number of CKey pages
+    pub ckey_page_count: u32,
+    /// Number of EKey pages
+    pub ekey_page_count: u32,
+    /// Unknown field (must be 0)
+    pub unk: u8,
+    /// ESpec block size
+    pub espec_block_size: u32,
+}
+
+/// Page table entry
+#[derive(Debug, Clone)]
+pub struct PageInfo {
+    /// First hash in this page
+    pub first_hash: Vec<u8>,
+    /// MD5 checksum of the page
+    pub checksum: [u8; 16],
+}
+
+/// Encoding entry for a content key
+#[derive(Debug, Clone)]
+pub struct EncodingEntry {
+    /// The content key
+    pub content_key: Vec<u8>,
+    /// List of encoding keys for this content
+    pub encoding_keys: Vec<Vec<u8>>,
+    /// File size (40-bit integer)
+    pub size: u64,
+}
+
+/// Encoding file parser and lookup
+pub struct EncodingFile {
+    /// File header
+    pub header: EncodingHeader,
+    /// CKey → EncodingEntry mapping
+    ckey_entries: HashMap<Vec<u8>, EncodingEntry>,
+    /// EKey → CKey reverse mapping
+    ekey_to_ckey: HashMap<Vec<u8>, Vec<u8>>,
+}
+
+impl EncodingFile {
+    /// Parse an encoding file from raw data
+    pub fn parse(data: &[u8]) -> Result<Self> {
+        let mut cursor = Cursor::new(data);
+        
+        // Parse header
+        let header = Self::parse_header(&mut cursor)?;
+        debug!("Parsed encoding header: version={}, ckey_pages={}, ekey_pages={}", 
+               header.version, header.ckey_page_count, header.ekey_page_count);
+        
+        // Parse CKey page table
+        let ckey_page_table = Self::parse_page_table(
+            &mut cursor,
+            header.ckey_page_count as usize,
+            header.ckey_hash_size as usize,
+        )?;
+        trace!("Parsed {} CKey page table entries", ckey_page_table.len());
+        
+        // Parse EKey page table
+        let _ekey_page_table = Self::parse_page_table(
+            &mut cursor,
+            header.ekey_page_count as usize,
+            header.ekey_hash_size as usize,
+        )?;
+        trace!("Parsed {} EKey page table entries", _ekey_page_table.len());
+        
+        // Parse CKey pages
+        let mut ckey_entries = HashMap::new();
+        let page_size = header.ckey_page_size_kb as usize * 1024;
+        
+        for (i, page_info) in ckey_page_table.iter().enumerate() {
+            let page_data = Self::read_page(&mut cursor, page_size)?;
+            
+            // Verify page checksum
+            let checksum = md5::compute(&page_data);
+            if checksum.0 != page_info.checksum {
+                warn!("CKey page {} checksum mismatch", i);
+            }
+            
+            Self::parse_ckey_page(
+                &page_data,
+                header.ckey_hash_size,
+                header.ekey_hash_size,
+                &mut ckey_entries,
+            )?;
+        }
+        
+        debug!("Parsed {} CKey entries", ckey_entries.len());
+        
+        // Build reverse mapping (EKey → CKey)
+        let mut ekey_to_ckey = HashMap::new();
+        for entry in ckey_entries.values() {
+            for ekey in &entry.encoding_keys {
+                ekey_to_ckey.insert(ekey.clone(), entry.content_key.clone());
+            }
+        }
+        
+        debug!("Built EKey→CKey reverse mapping with {} entries", ekey_to_ckey.len());
+        
+        Ok(Self {
+            header,
+            ckey_entries,
+            ekey_to_ckey,
+        })
+    }
+    
+    /// Parse the encoding file header
+    fn parse_header<R: Read>(reader: &mut R) -> Result<EncodingHeader> {
+        let mut magic = [0u8; 2];
+        reader.read_exact(&mut magic)?;
+        
+        if magic != ENCODING_MAGIC {
+            return Err(Error::BadMagic);
+        }
+        
+        let version = reader.read_u8()?;
+        if version != 1 {
+            warn!("Unexpected encoding version: {}", version);
+        }
+        
+        let ckey_hash_size = reader.read_u8()?;
+        let ekey_hash_size = reader.read_u8()?;
+        let ckey_page_size_kb = reader.read_u16::<BigEndian>()?; // BIG-ENDIAN!
+        let ekey_page_size_kb = reader.read_u16::<BigEndian>()?; // BIG-ENDIAN!
+        let ckey_page_count = reader.read_u32::<BigEndian>()?;   // BIG-ENDIAN!
+        let ekey_page_count = reader.read_u32::<BigEndian>()?;   // BIG-ENDIAN!
+        let unk = reader.read_u8()?;
+        let espec_block_size = reader.read_u32::<BigEndian>()?;  // BIG-ENDIAN!
+        
+        Ok(EncodingHeader {
+            magic,
+            version,
+            ckey_hash_size,
+            ekey_hash_size,
+            ckey_page_size_kb,
+            ekey_page_size_kb,
+            ckey_page_count,
+            ekey_page_count,
+            unk,
+            espec_block_size,
+        })
+    }
+    
+    /// Parse a page table
+    fn parse_page_table<R: Read>(
+        reader: &mut R,
+        page_count: usize,
+        hash_size: usize,
+    ) -> Result<Vec<PageInfo>> {
+        let mut pages = Vec::with_capacity(page_count);
+        
+        for _ in 0..page_count {
+            let mut first_hash = vec![0u8; hash_size];
+            reader.read_exact(&mut first_hash)?;
+            
+            let mut checksum = [0u8; 16];
+            reader.read_exact(&mut checksum)?;
+            
+            pages.push(PageInfo {
+                first_hash,
+                checksum,
+            });
+        }
+        
+        Ok(pages)
+    }
+    
+    /// Read a page of data
+    fn read_page<R: Read>(reader: &mut R, page_size: usize) -> Result<Vec<u8>> {
+        let mut page = vec![0u8; page_size];
+        reader.read_exact(&mut page)?;
+        Ok(page)
+    }
+    
+    /// Parse a CKey page
+    fn parse_ckey_page(
+        data: &[u8],
+        ckey_size: u8,
+        ekey_size: u8,
+        entries: &mut HashMap<Vec<u8>, EncodingEntry>,
+    ) -> Result<()> {
+        let mut offset = 0;
+        
+        while offset < data.len() {
+            // Check for zero padding (end of page data)
+            if offset + 6 > data.len() || data[offset..].iter().all(|&b| b == 0) {
+                break;
+            }
+            
+            // Read key count
+            let key_count = data[offset];
+            offset += 1;
+            
+            if key_count == 0 {
+                break; // End of entries
+            }
+            
+            // Read file size (40-bit integer!)
+            if offset + 5 > data.len() {
+                break;
+            }
+            let size = crate::utils::read_uint40(&data[offset..offset + 5])?;
+            offset += 5;
+            
+            // Read content key
+            if offset + ckey_size as usize > data.len() {
+                break;
+            }
+            let ckey = data[offset..offset + ckey_size as usize].to_vec();
+            offset += ckey_size as usize;
+            
+            // Read encoding keys
+            let mut ekeys = Vec::new();
+            for _ in 0..key_count {
+                if offset + ekey_size as usize > data.len() {
+                    break;
+                }
+                let ekey = data[offset..offset + ekey_size as usize].to_vec();
+                offset += ekey_size as usize;
+                ekeys.push(ekey);
+            }
+            
+            entries.insert(ckey.clone(), EncodingEntry {
+                content_key: ckey,
+                encoding_keys: ekeys,
+                size,
+            });
+        }
+        
+        Ok(())
+    }
+    
+    /// Look up encoding keys by content key
+    pub fn lookup_by_ckey(&self, ckey: &[u8]) -> Option<&EncodingEntry> {
+        self.ckey_entries.get(ckey)
+    }
+    
+    /// Look up content key by encoding key
+    pub fn lookup_by_ekey(&self, ekey: &[u8]) -> Option<&Vec<u8>> {
+        self.ekey_to_ckey.get(ekey)
+    }
+    
+    /// Get the first encoding key for a content key (most common case)
+    pub fn get_ekey_for_ckey(&self, ckey: &[u8]) -> Option<&Vec<u8>> {
+        self.ckey_entries
+            .get(ckey)
+            .and_then(|entry| entry.encoding_keys.first())
+    }
+    
+    /// Get file size for a content key
+    pub fn get_file_size(&self, ckey: &[u8]) -> Option<u64> {
+        self.ckey_entries.get(ckey).map(|entry| entry.size)
+    }
+    
+    /// Get total number of content keys
+    pub fn ckey_count(&self) -> usize {
+        self.ckey_entries.len()
+    }
+    
+    /// Get total number of encoding keys
+    pub fn ekey_count(&self) -> usize {
+        self.ekey_to_ckey.len()
+    }
+}
+
+/// MD5 module for checksums
+mod md5 {
+    use std::io::Write;
+    
+    pub struct Digest(pub [u8; 16]);
+    
+    pub fn compute(data: &[u8]) -> Digest {
+        // For now, return a dummy checksum
+        // In production, use a proper MD5 implementation like md5 crate
+        let mut hasher = DummyMd5::new();
+        hasher.write_all(data).unwrap();
+        Digest(hasher.finish())
+    }
+    
+    struct DummyMd5 {
+        data: Vec<u8>,
+    }
+    
+    impl DummyMd5 {
+        fn new() -> Self {
+            Self { data: Vec::new() }
+        }
+        
+        fn finish(self) -> [u8; 16] {
+            // This is just a placeholder - replace with real MD5
+            let mut result = [0u8; 16];
+            for (i, byte) in self.data.iter().take(16).enumerate() {
+                result[i] = *byte;
+            }
+            result
+        }
+    }
+    
+    impl Write for DummyMd5 {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.data.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_encoding_header_size() {
+        // Header should be exactly 22 bytes
+        let header_size = 2 + 1 + 1 + 1 + 2 + 2 + 4 + 4 + 1 + 4;
+        assert_eq!(header_size, 22);
+    }
+    
+    #[test]
+    fn test_parse_empty_encoding() {
+        // Create a minimal valid encoding file
+        let mut data = Vec::new();
+        
+        // Magic
+        data.extend_from_slice(&ENCODING_MAGIC);
+        // Version
+        data.push(1);
+        // Hash sizes
+        data.push(16); // CKey hash size
+        data.push(16); // EKey hash size
+        // Page sizes (big-endian!)
+        data.extend_from_slice(&0u16.to_be_bytes()); // CKey page size
+        data.extend_from_slice(&0u16.to_be_bytes()); // EKey page size
+        // Page counts (big-endian!)
+        data.extend_from_slice(&0u32.to_be_bytes()); // CKey page count
+        data.extend_from_slice(&0u32.to_be_bytes()); // EKey page count
+        // Unknown
+        data.push(0);
+        // ESpec block size (big-endian!)
+        data.extend_from_slice(&0u32.to_be_bytes());
+        
+        let result = EncodingFile::parse(&data);
+        assert!(result.is_ok());
+        
+        let encoding = result.unwrap();
+        assert_eq!(encoding.header.version, 1);
+        assert_eq!(encoding.header.ckey_hash_size, 16);
+        assert_eq!(encoding.header.ekey_hash_size, 16);
+        assert_eq!(encoding.ckey_count(), 0);
+        assert_eq!(encoding.ekey_count(), 0);
+    }
+    
+    #[test]
+    fn test_invalid_magic() {
+        let mut data = vec![0xFF, 0xFF]; // Wrong magic
+        data.push(1); // Version
+        
+        let result = EncodingFile::parse(&data);
+        assert!(matches!(result, Err(Error::BadMagic)));
+    }
+}

--- a/tact-parser/src/install.rs
+++ b/tact-parser/src/install.rs
@@ -1,0 +1,362 @@
+//! Install manifest parser for TACT
+//!
+//! The install manifest lists files that need to be installed for the game to run.
+//! Files are associated with tags (e.g., "Windows", "Mac", "enUS") using a bitmask system.
+
+use byteorder::{BigEndian, ReadBytesExt};
+use std::io::{Cursor, Read};
+use tracing::{debug, trace};
+
+use crate::{Error, Result};
+use crate::utils::read_cstring_from;
+
+/// Magic bytes for install manifest: "IN"
+const INSTALL_MAGIC: [u8; 2] = [0x49, 0x4E]; // 'I', 'N'
+
+/// Install manifest header
+#[derive(Debug, Clone)]
+pub struct InstallHeader {
+    /// Magic bytes "IN"
+    pub magic: [u8; 2],
+    /// Version (should be 1)
+    pub version: u8,
+    /// Hash size (usually 16 for MD5)
+    pub hash_size: u8,
+    /// Number of tags
+    pub tag_count: u16,
+    /// Number of file entries
+    pub entry_count: u32,
+}
+
+/// Install tag information
+#[derive(Debug, Clone)]
+pub struct InstallTag {
+    /// Tag name (e.g., "Windows", "Mac", "enUS")
+    pub name: String,
+    /// Tag type/flags
+    pub tag_type: u16,
+    /// Bitmask indicating which files have this tag
+    pub files_mask: Vec<bool>,
+}
+
+/// Install file entry
+#[derive(Debug, Clone)]
+pub struct InstallEntry {
+    /// File path relative to game root
+    pub path: String,
+    /// Content key (CKey)
+    pub ckey: Vec<u8>,
+    /// File size
+    pub size: u32,
+    /// Tags associated with this file
+    pub tags: Vec<String>,
+}
+
+/// Install manifest
+pub struct InstallManifest {
+    /// File header
+    pub header: InstallHeader,
+    /// List of tags
+    pub tags: Vec<InstallTag>,
+    /// List of file entries
+    pub entries: Vec<InstallEntry>,
+}
+
+/// Common platform tags
+#[derive(Debug, Clone, PartialEq)]
+pub enum Platform {
+    Windows,
+    Mac,
+    Linux,
+    All,
+}
+
+impl Platform {
+    /// Get the tag name for this platform
+    pub fn tag_name(&self) -> &str {
+        match self {
+            Platform::Windows => "Windows",
+            Platform::Mac => "OSX",
+            Platform::Linux => "Linux",
+            Platform::All => "",
+        }
+    }
+}
+
+impl InstallManifest {
+    /// Parse an install manifest from raw data
+    pub fn parse(data: &[u8]) -> Result<Self> {
+        let mut cursor = Cursor::new(data);
+        
+        // Parse header
+        let header = Self::parse_header(&mut cursor)?;
+        debug!("Parsed install header: version={}, tags={}, entries={}", 
+               header.version, header.tag_count, header.entry_count);
+        
+        // Calculate bytes per tag for bitmask
+        let bytes_per_tag = ((header.entry_count + 7) / 8) as usize;
+        
+        // Parse tags
+        let mut tags = Vec::with_capacity(header.tag_count as usize);
+        for i in 0..header.tag_count {
+            let name = read_cstring_from(&mut cursor)?;
+            let tag_type = cursor.read_u16::<BigEndian>()?;
+            
+            // Read bitmask for this tag
+            let mut mask_bytes = vec![0u8; bytes_per_tag];
+            cursor.read_exact(&mut mask_bytes)?;
+            
+            // Convert bytes to bool vector
+            let mut files_mask = Vec::with_capacity(header.entry_count as usize);
+            for byte in mask_bytes {
+                for bit in 0..8 {
+                    if files_mask.len() < header.entry_count as usize {
+                        files_mask.push((byte & (1 << bit)) != 0);
+                    }
+                }
+            }
+            
+            trace!("Tag {}: name='{}', type={:#06x}, files_with_tag={}", 
+                   i, name, tag_type, files_mask.iter().filter(|&&b| b).count());
+            
+            tags.push(InstallTag {
+                name,
+                tag_type,
+                files_mask,
+            });
+        }
+        
+        // Parse file entries
+        let mut entries = Vec::with_capacity(header.entry_count as usize);
+        for i in 0..header.entry_count {
+            let path = read_cstring_from(&mut cursor)?;
+            
+            let mut ckey = vec![0u8; header.hash_size as usize];
+            cursor.read_exact(&mut ckey)?;
+            
+            let size = cursor.read_u32::<BigEndian>()?;
+            
+            // Resolve tags for this entry
+            let mut entry_tags = Vec::new();
+            for tag in &tags {
+                if tag.files_mask[i as usize] {
+                    entry_tags.push(tag.name.clone());
+                }
+            }
+            
+            entries.push(InstallEntry {
+                path,
+                ckey,
+                size,
+                tags: entry_tags,
+            });
+        }
+        
+        debug!("Parsed {} install entries", entries.len());
+        
+        Ok(InstallManifest {
+            header,
+            tags,
+            entries,
+        })
+    }
+    
+    /// Parse the install manifest header
+    fn parse_header<R: Read>(reader: &mut R) -> Result<InstallHeader> {
+        let mut magic = [0u8; 2];
+        reader.read_exact(&mut magic)?;
+        
+        if magic != INSTALL_MAGIC {
+            return Err(Error::BadMagic);
+        }
+        
+        let version = reader.read_u8()?;
+        let hash_size = reader.read_u8()?;
+        let tag_count = reader.read_u16::<BigEndian>()?;
+        let entry_count = reader.read_u32::<BigEndian>()?;
+        
+        Ok(InstallHeader {
+            magic,
+            version,
+            hash_size,
+            tag_count,
+            entry_count,
+        })
+    }
+    
+    /// Get all files that have specific tags
+    pub fn get_files_for_tags(&self, required_tags: &[&str]) -> Vec<&InstallEntry> {
+        self.entries
+            .iter()
+            .filter(|entry| {
+                required_tags.iter().all(|tag| entry.tags.contains(&tag.to_string()))
+            })
+            .collect()
+    }
+    
+    /// Get all files for a specific platform
+    pub fn get_files_for_platform(&self, platform: Platform) -> Vec<&InstallEntry> {
+        if platform == Platform::All {
+            return self.entries.iter().collect();
+        }
+        
+        let tag_name = platform.tag_name();
+        self.get_files_for_tags(&[tag_name])
+    }
+    
+    /// Get all unique tags in the manifest
+    pub fn get_all_tags(&self) -> Vec<&str> {
+        self.tags.iter().map(|t| t.name.as_str()).collect()
+    }
+    
+    /// Get a specific file by path
+    pub fn get_file_by_path(&self, path: &str) -> Option<&InstallEntry> {
+        self.entries.iter().find(|e| e.path == path)
+    }
+    
+    /// Calculate total size for files with specific tags
+    pub fn calculate_size_for_tags(&self, tags: &[&str]) -> u64 {
+        self.get_files_for_tags(tags)
+            .iter()
+            .map(|entry| entry.size as u64)
+            .sum()
+    }
+    
+    /// Calculate total size for a platform
+    pub fn calculate_size_for_platform(&self, platform: Platform) -> u64 {
+        self.get_files_for_platform(platform)
+            .iter()
+            .map(|entry| entry.size as u64)
+            .sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_install_header_size() {
+        // Header should be exactly 10 bytes
+        let header_size = 2 + 1 + 1 + 2 + 4;
+        assert_eq!(header_size, 10);
+    }
+    
+    #[test]
+    fn test_parse_empty_install() {
+        // Create a minimal valid install manifest
+        let mut data = Vec::new();
+        
+        // Magic
+        data.extend_from_slice(&INSTALL_MAGIC);
+        // Version
+        data.push(1);
+        // Hash size
+        data.push(16);
+        // Tag count (big-endian!)
+        data.extend_from_slice(&0u16.to_be_bytes());
+        // Entry count (big-endian!)
+        data.extend_from_slice(&0u32.to_be_bytes());
+        
+        let result = InstallManifest::parse(&data);
+        assert!(result.is_ok());
+        
+        let manifest = result.unwrap();
+        assert_eq!(manifest.header.version, 1);
+        assert_eq!(manifest.header.hash_size, 16);
+        assert_eq!(manifest.tags.len(), 0);
+        assert_eq!(manifest.entries.len(), 0);
+    }
+    
+    #[test]
+    fn test_invalid_magic() {
+        let mut data = vec![0xFF, 0xFF]; // Wrong magic
+        data.push(1); // Version
+        
+        let result = InstallManifest::parse(&data);
+        assert!(matches!(result, Err(Error::BadMagic)));
+    }
+    
+    #[test]
+    fn test_parse_with_tags() {
+        // Create an install manifest with one tag and one file
+        let mut data = Vec::new();
+        
+        // Header
+        data.extend_from_slice(&INSTALL_MAGIC);
+        data.push(1); // Version
+        data.push(16); // Hash size
+        data.extend_from_slice(&1u16.to_be_bytes()); // 1 tag
+        data.extend_from_slice(&1u32.to_be_bytes()); // 1 entry
+        
+        // Tag
+        data.extend_from_slice(b"Windows\0"); // Tag name
+        data.extend_from_slice(&0u16.to_be_bytes()); // Tag type
+        data.push(0x01); // Bitmask: first file has this tag
+        
+        // Entry
+        data.extend_from_slice(b"test.exe\0"); // File path
+        data.extend_from_slice(&[0u8; 16]); // CKey (16 bytes of zeros)
+        data.extend_from_slice(&1024u32.to_be_bytes()); // Size
+        
+        let result = InstallManifest::parse(&data);
+        assert!(result.is_ok());
+        
+        let manifest = result.unwrap();
+        assert_eq!(manifest.tags.len(), 1);
+        assert_eq!(manifest.tags[0].name, "Windows");
+        assert_eq!(manifest.entries.len(), 1);
+        assert_eq!(manifest.entries[0].path, "test.exe");
+        assert_eq!(manifest.entries[0].size, 1024);
+        assert!(manifest.entries[0].tags.contains(&"Windows".to_string()));
+    }
+    
+    #[test]
+    fn test_platform_filtering() {
+        // Create a manifest with Windows and Mac files
+        let mut data = Vec::new();
+        
+        // Header
+        data.extend_from_slice(&INSTALL_MAGIC);
+        data.push(1); // Version
+        data.push(16); // Hash size
+        data.extend_from_slice(&2u16.to_be_bytes()); // 2 tags
+        data.extend_from_slice(&2u32.to_be_bytes()); // 2 entries
+        
+        // Tag 1: Windows
+        data.extend_from_slice(b"Windows\0");
+        data.extend_from_slice(&0u16.to_be_bytes());
+        data.push(0x01); // First file has Windows tag
+        
+        // Tag 2: OSX
+        data.extend_from_slice(b"OSX\0");
+        data.extend_from_slice(&0u16.to_be_bytes());
+        data.push(0x02); // Second file has OSX tag
+        
+        // Entry 1: Windows file
+        data.extend_from_slice(b"windows.exe\0");
+        data.extend_from_slice(&[1u8; 16]);
+        data.extend_from_slice(&1000u32.to_be_bytes());
+        
+        // Entry 2: Mac file
+        data.extend_from_slice(b"mac.app\0");
+        data.extend_from_slice(&[2u8; 16]);
+        data.extend_from_slice(&2000u32.to_be_bytes());
+        
+        let manifest = InstallManifest::parse(&data).unwrap();
+        
+        // Test platform filtering
+        let windows_files = manifest.get_files_for_platform(Platform::Windows);
+        assert_eq!(windows_files.len(), 1);
+        assert_eq!(windows_files[0].path, "windows.exe");
+        
+        let mac_files = manifest.get_files_for_platform(Platform::Mac);
+        assert_eq!(mac_files.len(), 1);
+        assert_eq!(mac_files[0].path, "mac.app");
+        
+        // Test size calculation
+        assert_eq!(manifest.calculate_size_for_platform(Platform::Windows), 1000);
+        assert_eq!(manifest.calculate_size_for_platform(Platform::Mac), 2000);
+        assert_eq!(manifest.calculate_size_for_platform(Platform::All), 3000);
+    }
+}

--- a/tact-parser/src/lib.rs
+++ b/tact-parser/src/lib.rs
@@ -40,9 +40,15 @@
 //!
 //! - ✅ WoW Root file parsing
 //! - ✅ Jenkins3 hash implementation
-//! - ⏳ Encoding table parsing (planned)
-//! - ⏳ BLTE file decoding (planned)
-//! - ⏳ Patch file support (planned)
+//! - ✅ Encoding file parsing (CKey ↔ EKey mapping)
+//! - ✅ Install manifest parsing (with tag-based filtering)
+//! - ✅ Build/CDN config parsing
+//! - ✅ 40-bit integer support
+//! - ✅ Variable-length integer support
+//! - ⏳ Download manifest parsing (planned)
+//! - ⏳ Size file parsing (planned)
+//! - ⏳ TVFS support (planned)
+//! - ⏳ BLTE file decoding (planned - separate crate)
 //!
 //! ## See Also
 //!
@@ -52,6 +58,9 @@
 
 mod error;
 mod ioutils;
+pub mod config;
+pub mod encoding;
+pub mod install;
 pub mod jenkins3;
 pub mod utils;
 pub mod wow_root;

--- a/tact-parser/src/utils.rs
+++ b/tact-parser/src/utils.rs
@@ -1,4 +1,7 @@
+//! Utility functions for binary operations used in TACT file formats
+
 use crate::jenkins3::hashlittle2;
+use crate::{Error, Result};
 
 /// Perform a [`HashPath`][0] with [`hashlittle2`][] (aka: jenkins3).
 ///
@@ -15,4 +18,388 @@ pub fn jenkins3_hashpath(path: &str) -> u64 {
     hashlittle2(normalised.as_bytes(), &mut pc, &mut pb);
 
     (u64::from(pc) << 32) | u64::from(pb)
+}
+
+/// Read a 40-bit (5-byte) unsigned integer from a byte slice (little-endian)
+/// 
+/// 40-bit integers are used throughout TACT formats for file sizes and offsets.
+/// They allow representing values up to 1TB while saving space compared to 64-bit.
+/// 
+/// # Arguments
+/// * `data` - Byte slice containing at least 5 bytes
+/// 
+/// # Returns
+/// * The 40-bit value as a u64
+/// 
+/// # Errors
+/// * Returns error if data contains less than 5 bytes
+/// 
+/// # Example
+/// ```
+/// use tact_parser::utils::read_uint40;
+/// 
+/// let data = [0x12, 0x34, 0x56, 0x78, 0x9A];
+/// let value = read_uint40(&data).unwrap();
+/// assert_eq!(value, 0x9A78563412);
+/// ```
+pub fn read_uint40(data: &[u8]) -> Result<u64> {
+    if data.len() < 5 {
+        return Err(Error::IOError(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            format!("Need 5 bytes for uint40, got {}", data.len()),
+        )));
+    }
+    
+    Ok((data[0] as u64)
+        | ((data[1] as u64) << 8)
+        | ((data[2] as u64) << 16)
+        | ((data[3] as u64) << 24)
+        | ((data[4] as u64) << 32))
+}
+
+/// Write a 40-bit (5-byte) unsigned integer to a byte array (little-endian)
+/// 
+/// # Arguments
+/// * `value` - The value to write (must fit in 40 bits)
+/// 
+/// # Returns
+/// * A 5-byte array containing the value in little-endian format
+/// 
+/// # Panics
+/// * Panics if value exceeds 40-bit range (>= 2^40)
+/// 
+/// # Example
+/// ```
+/// use tact_parser::utils::write_uint40;
+/// 
+/// let bytes = write_uint40(0x9A78563412);
+/// assert_eq!(bytes, [0x12, 0x34, 0x56, 0x78, 0x9A]);
+/// ```
+pub fn write_uint40(value: u64) -> [u8; 5] {
+    assert!(
+        value < (1u64 << 40),
+        "Value {:#x} exceeds 40-bit range",
+        value
+    );
+    
+    [
+        (value & 0xFF) as u8,
+        ((value >> 8) & 0xFF) as u8,
+        ((value >> 16) & 0xFF) as u8,
+        ((value >> 24) & 0xFF) as u8,
+        ((value >> 32) & 0xFF) as u8,
+    ]
+}
+
+/// Read a 40-bit unsigned integer from a cursor (little-endian)
+/// 
+/// This is a convenience function for use with `std::io::Cursor` or `BufReader`.
+/// 
+/// # Arguments
+/// * `reader` - A reader implementing `std::io::Read`
+/// 
+/// # Returns
+/// * The 40-bit value as a u64
+/// 
+/// # Errors
+/// * Returns error if unable to read 5 bytes
+pub fn read_uint40_from<R: std::io::Read>(reader: &mut R) -> Result<u64> {
+    let mut buf = [0u8; 5];
+    reader.read_exact(&mut buf)?;
+    read_uint40(&buf)
+}
+
+/// Read a variable-length integer from a byte slice
+/// 
+/// Variable-length integers use 7 bits per byte with a continuation bit.
+/// This is compatible with protobuf/varint encoding.
+/// 
+/// # Arguments
+/// * `data` - Byte slice to read from
+/// 
+/// # Returns
+/// * Tuple of (value, bytes_consumed)
+/// 
+/// # Errors
+/// * Returns error if varint is malformed or exceeds 5 bytes
+/// 
+/// # Example
+/// ```
+/// use tact_parser::utils::read_varint;
+/// 
+/// let data = [0x08]; // Value 8
+/// let (value, consumed) = read_varint(&data).unwrap();
+/// assert_eq!(value, 8);
+/// assert_eq!(consumed, 1);
+/// 
+/// let data = [0x96, 0x01]; // Value 150
+/// let (value, consumed) = read_varint(&data).unwrap();
+/// assert_eq!(value, 150);
+/// assert_eq!(consumed, 2);
+/// ```
+pub fn read_varint(data: &[u8]) -> Result<(u32, usize)> {
+    let mut result = 0u32;
+    let mut shift = 0;
+    let mut consumed = 0;
+    
+    for &byte in data {
+        consumed += 1;
+        
+        // Extract 7-bit value
+        let value = (byte & 0x7F) as u32;
+        
+        // Check for overflow
+        if shift >= 32 || (shift == 28 && value > 0x0F) {
+            return Err(Error::IOError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Varint exceeds 32-bit range",
+            )));
+        }
+        
+        result |= value << shift;
+        
+        // Check continuation bit
+        if byte & 0x80 == 0 {
+            return Ok((result, consumed));
+        }
+        
+        shift += 7;
+        
+        // Varints shouldn't exceed 5 bytes for 32-bit values
+        if consumed >= 5 {
+            return Err(Error::IOError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Varint exceeds maximum length",
+            )));
+        }
+    }
+    
+    Err(Error::IOError(std::io::Error::new(
+        std::io::ErrorKind::UnexpectedEof,
+        "Incomplete varint",
+    )))
+}
+
+/// Write a variable-length integer to a byte vector
+/// 
+/// # Arguments
+/// * `value` - The value to encode
+/// 
+/// # Returns
+/// * A vector containing the encoded varint
+/// 
+/// # Example
+/// ```
+/// use tact_parser::utils::write_varint;
+/// 
+/// let encoded = write_varint(8);
+/// assert_eq!(encoded, vec![0x08]);
+/// 
+/// let encoded = write_varint(150);
+/// assert_eq!(encoded, vec![0x96, 0x01]);
+/// ```
+pub fn write_varint(mut value: u32) -> Vec<u8> {
+    let mut result = Vec::new();
+    
+    loop {
+        let mut byte = (value & 0x7F) as u8;
+        value >>= 7;
+        
+        if value != 0 {
+            byte |= 0x80; // Set continuation bit
+            result.push(byte);
+        } else {
+            result.push(byte);
+            break;
+        }
+    }
+    
+    result
+}
+
+/// Read a null-terminated C string from a byte slice
+/// 
+/// # Arguments
+/// * `data` - Byte slice to read from
+/// 
+/// # Returns
+/// * Tuple of (string, bytes_consumed)
+/// 
+/// # Errors
+/// * Returns error if no null terminator found or invalid UTF-8
+pub fn read_cstring(data: &[u8]) -> Result<(String, usize)> {
+    // Find null terminator
+    let null_pos = data
+        .iter()
+        .position(|&b| b == 0)
+        .ok_or_else(|| {
+            Error::IOError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "No null terminator found in C string",
+            ))
+        })?;
+    
+    // Convert to string
+    let string = std::str::from_utf8(&data[..null_pos])
+        .map_err(|e| {
+            Error::IOError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Invalid UTF-8 in C string: {}", e),
+            ))
+        })?
+        .to_string();
+    
+    Ok((string, null_pos + 1)) // +1 for null terminator
+}
+
+/// Read a C string from a reader
+/// 
+/// # Arguments
+/// * `reader` - A reader implementing `std::io::Read`
+/// 
+/// # Returns
+/// * The string without null terminator
+/// 
+/// # Errors
+/// * Returns error if unable to read or invalid UTF-8
+pub fn read_cstring_from<R: std::io::Read>(reader: &mut R) -> Result<String> {
+    let mut bytes = Vec::new();
+    let mut byte = [0u8; 1];
+    
+    loop {
+        reader.read_exact(&mut byte)?;
+        if byte[0] == 0 {
+            break;
+        }
+        bytes.push(byte[0]);
+    }
+    
+    String::from_utf8(bytes).map_err(|e| {
+        Error::IOError(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Invalid UTF-8 in C string: {}", e),
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_uint40_roundtrip() {
+        let test_values = [
+            0u64,
+            1,
+            255,
+            256,
+            65535,
+            65536,
+            0xFFFFFFFF,
+            0x123456789A,
+            0xFFFFFFFFFF, // Max 40-bit value
+        ];
+        
+        for value in test_values {
+            let bytes = write_uint40(value);
+            let decoded = read_uint40(&bytes).unwrap();
+            assert_eq!(value, decoded, "Failed for value {:#x}", value);
+        }
+    }
+    
+    #[test]
+    fn test_uint40_little_endian() {
+        let data = [0x12, 0x34, 0x56, 0x78, 0x9A];
+        let value = read_uint40(&data).unwrap();
+        assert_eq!(value, 0x9A78563412);
+        
+        let bytes = write_uint40(0x9A78563412);
+        assert_eq!(bytes, [0x12, 0x34, 0x56, 0x78, 0x9A]);
+    }
+    
+    #[test]
+    #[should_panic(expected = "exceeds 40-bit range")]
+    fn test_uint40_overflow() {
+        write_uint40(0x10000000000); // 2^40
+    }
+    
+    #[test]
+    fn test_uint40_insufficient_data() {
+        let data = [0x12, 0x34, 0x56, 0x78]; // Only 4 bytes
+        assert!(read_uint40(&data).is_err());
+    }
+    
+    #[test]
+    fn test_varint_single_byte() {
+        let data = [0x08];
+        let (value, consumed) = read_varint(&data).unwrap();
+        assert_eq!(value, 8);
+        assert_eq!(consumed, 1);
+        
+        let encoded = write_varint(8);
+        assert_eq!(encoded, vec![0x08]);
+    }
+    
+    #[test]
+    fn test_varint_multi_byte() {
+        let data = [0x96, 0x01]; // 150 = 0x96
+        let (value, consumed) = read_varint(&data).unwrap();
+        assert_eq!(value, 150);
+        assert_eq!(consumed, 2);
+        
+        let encoded = write_varint(150);
+        assert_eq!(encoded, vec![0x96, 0x01]);
+    }
+    
+    #[test]
+    fn test_varint_max_value() {
+        let value = 0xFFFFFFFF;
+        let encoded = write_varint(value);
+        let (decoded, _) = read_varint(&encoded).unwrap();
+        assert_eq!(decoded, value);
+    }
+    
+    #[test]
+    fn test_varint_known_values() {
+        // Test cases from protobuf spec
+        let test_cases = [
+            (0, vec![0x00]),
+            (1, vec![0x01]),
+            (127, vec![0x7F]),
+            (128, vec![0x80, 0x01]),
+            (300, vec![0xAC, 0x02]),
+            (16384, vec![0x80, 0x80, 0x01]),
+        ];
+        
+        for (value, expected) in test_cases {
+            let encoded = write_varint(value);
+            assert_eq!(encoded, expected, "Encoding failed for {}", value);
+            
+            let (decoded, consumed) = read_varint(&expected).unwrap();
+            assert_eq!(decoded, value, "Decoding failed for {}", value);
+            assert_eq!(consumed, expected.len());
+        }
+    }
+    
+    #[test]
+    fn test_cstring() {
+        let data = b"Hello, World!\0extra data";
+        let (string, consumed) = read_cstring(data).unwrap();
+        assert_eq!(string, "Hello, World!");
+        assert_eq!(consumed, 14); // Including null terminator
+    }
+    
+    #[test]
+    fn test_cstring_empty() {
+        let data = b"\0";
+        let (string, consumed) = read_cstring(data).unwrap();
+        assert_eq!(string, "");
+        assert_eq!(consumed, 1);
+    }
+    
+    #[test]
+    fn test_cstring_no_terminator() {
+        let data = b"No null here";
+        assert!(read_cstring(data).is_err());
+    }
 }

--- a/tact-parser/tests/config_tests.rs
+++ b/tact-parser/tests/config_tests.rs
@@ -1,0 +1,244 @@
+//! Integration tests for configuration file parsing
+
+use tact_parser::config::{ConfigFile, BuildConfig, CdnConfig};
+
+#[test]
+fn test_real_world_build_config() {
+    // Real-world build config format based on TACT.Net and actual NGDP data
+    let config_text = r#"# Build Configuration
+
+## seqn = 3136135
+root = 70c8ce1f7cf81302bc0341211b499809 31519
+install = 79e1afb713f96ca3e9f049aca3f1b433 8192
+install-size = 79e1afb713f96ca3e9f049aca3f1b433 8192
+download = fb5ba2d2eef871e31d28c73e5d883754 16827
+download-size = fb5ba2d2eef871e31d28c73e5d883754 16827
+size = d8fbe632f4a0cf1d95ad2e663c32c1f1 56788
+size-size = d8fbe632f4a0cf1d95ad2e663c32c1f1 56788
+encoding = 9e3f7e6dc5e526ad88d14332fecb6a12 891234 0a3f7e6dc5e526ad88d14332fecb6a13 891235
+encoding-size = 9e3f7e6dc5e526ad88d14332fecb6a12 891234 0a3f7e6dc5e526ad88d14332fecb6a13 891235
+patch = 
+patch-size = 
+patch-config = 
+build-name = 1.15.7.61582
+build-uid = wow_classic_era
+build-product = WoW
+build-playbuild-installer = ngdp:us:wow_classic_era
+build-partial-priority = 
+vfs-root = manifest.dat 0
+vfs-1 = interface.dat 0
+vfs-2 = 
+vfs-3 = 
+    "#;
+    
+    let config = BuildConfig::parse(config_text).unwrap();
+    
+    // Test hash lookups
+    assert_eq!(config.root_hash(), Some("70c8ce1f7cf81302bc0341211b499809"));
+    assert_eq!(config.encoding_hash(), Some("9e3f7e6dc5e526ad88d14332fecb6a12"));
+    assert_eq!(config.install_hash(), Some("79e1afb713f96ca3e9f049aca3f1b433"));
+    assert_eq!(config.download_hash(), Some("fb5ba2d2eef871e31d28c73e5d883754"));
+    assert_eq!(config.size_hash(), Some("d8fbe632f4a0cf1d95ad2e663c32c1f1"));
+    
+    // Test build info
+    assert_eq!(config.build_name(), Some("1.15.7.61582"));
+    assert_eq!(config.config.get_value("build-uid"), Some("wow_classic_era"));
+    assert_eq!(config.config.get_value("build-product"), Some("WoW"));
+    
+    // Test size lookups
+    assert_eq!(config.config.get_size("root"), Some(31519));
+    assert_eq!(config.config.get_size("encoding"), Some(891234));
+    
+    // Test VFS entries
+    assert_eq!(config.config.get_value("vfs-root"), Some("manifest.dat 0"));
+    assert_eq!(config.config.get_value("vfs-1"), Some("interface.dat 0"));
+    
+    // Test empty values
+    assert_eq!(config.config.get_value("patch"), Some(""));
+    assert_eq!(config.config.get_hash("patch"), None);
+}
+
+#[test]
+fn test_real_world_cdn_config() {
+    let config_text = r#"# CDN Configuration
+
+## seqn = 3136135
+archives = 00802ffe94f0bb8e6ee6057a5e84f03c 018767e62d1ba1e1d63c693deb2e771f 01cec8eb8fc8e5dd17c22eb882b690f0
+archives-index-size = 123456 234567 345678
+archive-group = fb3c60af492e4bc4863e323d087e7166
+patch-archives = 5782994e87743275c737f5e8d519cd1f 60bebc8d29bb2f6c4fb37bbfa440e36f
+patch-archives-index-size = 456789 567890
+file-index = eb439ef75c96c973c0c711117b76e61f 17024
+file-index-size = eb439ef75c96c973c0c711117b76e61f 17024
+patch-file-index = 1de5736c18db6e6bb3496fe635876dc8 2376
+patch-file-index-size = 1de5736c18db6e6bb3496fe635876dc8 2376
+    "#;
+    
+    let config = CdnConfig::parse(config_text).unwrap();
+    
+    // Test archives list
+    let archives = config.archives();
+    assert_eq!(archives.len(), 3);
+    assert_eq!(archives[0], "00802ffe94f0bb8e6ee6057a5e84f03c");
+    assert_eq!(archives[1], "018767e62d1ba1e1d63c693deb2e771f");
+    assert_eq!(archives[2], "01cec8eb8fc8e5dd17c22eb882b690f0");
+    
+    // Test archive group
+    assert_eq!(config.archive_group(), Some("fb3c60af492e4bc4863e323d087e7166"));
+    
+    // Test file index
+    assert_eq!(config.file_index(), Some("eb439ef75c96c973c0c711117b76e61f 17024"));
+    
+    // Test patch archives
+    let patch_archives_value = config.config.get_value("patch-archives").unwrap();
+    let patch_archives: Vec<&str> = patch_archives_value.split_whitespace().collect();
+    assert_eq!(patch_archives.len(), 2);
+    assert_eq!(patch_archives[0], "5782994e87743275c737f5e8d519cd1f");
+}
+
+#[test]
+fn test_mixed_value_types() {
+    let config_text = r#"# Mixed types of values
+
+simple-key = simple-value
+number-key = 12345
+hash-key = abc123def456 789012
+multi-hash = abc123 100 def456 200 789012 300
+quoted-value = "value with spaces"
+path-value = C:\Path\To\File.dat
+url-value = http://example.com/path
+empty-value = 
+    "#;
+    
+    let config = ConfigFile::parse(config_text).unwrap();
+    
+    // Simple values
+    assert_eq!(config.get_value("simple-key"), Some("simple-value"));
+    assert_eq!(config.get_value("number-key"), Some("12345"));
+    
+    // Hash detection
+    assert_eq!(config.get_hash("hash-key"), Some("abc123def456"));
+    assert_eq!(config.get_size("hash-key"), Some(789012));
+    
+    // Multi-hash only gets first pair
+    assert_eq!(config.get_hash("multi-hash"), Some("abc123"));
+    assert_eq!(config.get_size("multi-hash"), Some(100));
+    
+    // Complex values preserved as-is
+    assert_eq!(config.get_value("quoted-value"), Some("\"value with spaces\""));
+    assert_eq!(config.get_value("path-value"), Some("C:\\Path\\To\\File.dat"));
+    assert_eq!(config.get_value("url-value"), Some("http://example.com/path"));
+    
+    // Empty value
+    assert_eq!(config.get_value("empty-value"), Some(""));
+}
+
+#[test]
+fn test_case_sensitive_keys() {
+    let config_text = r#"
+key = value1
+Key = value2
+KEY = value3
+    "#;
+    
+    let config = ConfigFile::parse(config_text).unwrap();
+    
+    // Keys should be case-sensitive
+    assert_eq!(config.get_value("key"), Some("value1"));
+    assert_eq!(config.get_value("Key"), Some("value2"));
+    assert_eq!(config.get_value("KEY"), Some("value3"));
+    assert_eq!(config.get_value("kEy"), None);
+}
+
+#[test]
+fn test_special_characters_in_values() {
+    let config_text = r#"
+key1 = value=with=equals
+key2 = value with multiple   spaces
+key3 = value	with	tabs
+key4 = !@#$%^&*()_+-=[]{}|;':",./<>?
+key5 = 中文字符
+    "#;
+    
+    let config = ConfigFile::parse(config_text).unwrap();
+    
+    assert_eq!(config.get_value("key1"), Some("value=with=equals"));
+    assert_eq!(config.get_value("key2"), Some("value with multiple   spaces"));
+    assert_eq!(config.get_value("key3"), Some("value	with	tabs"));
+    assert_eq!(config.get_value("key4"), Some("!@#$%^&*()_+-=[]{}|;':\",./<>?"));
+    assert_eq!(config.get_value("key5"), Some("中文字符"));
+}
+
+#[test]
+fn test_config_keys_method() {
+    let config_text = r#"
+zebra = last
+apple = first
+middle = center
+    "#;
+    
+    let config = ConfigFile::parse(config_text).unwrap();
+    let keys = config.keys();
+    
+    // Should have all keys
+    assert_eq!(keys.len(), 3);
+    assert!(keys.contains(&"zebra"));
+    assert!(keys.contains(&"apple"));
+    assert!(keys.contains(&"middle"));
+}
+
+#[test]
+fn test_edge_cases() {
+    // Test various edge cases
+    let config_text = r#"
+# Leading/trailing spaces
+  spaced-key  =  spaced-value  
+# Multiple equals signs
+multi-equals = value = with = many = equals
+# No spaces around equals (should not parse)
+nospace=value
+# Extra spaces around equals
+extra   =   spaces
+# Just key, no value
+#no-value = 
+# Hash that's too short (less than 6 chars)
+short = abc 123
+# Hash with invalid characters
+invalid-hash = ghijkl 456
+    "#;
+    
+    let config = ConfigFile::parse(config_text).unwrap();
+    
+    // Trimmed keys and values
+    assert_eq!(config.get_value("spaced-key"), Some("spaced-value"));
+    
+    // Multiple equals - only first is separator
+    assert_eq!(config.get_value("multi-equals"), Some("value = with = many = equals"));
+    
+    // No spaces around = means it won't parse
+    assert_eq!(config.get_value("nospace"), None);
+    
+    // Extra spaces work
+    assert_eq!(config.get_value("extra"), Some("spaces"));
+    
+    // Short hash not detected as hash
+    assert_eq!(config.get_hash("short"), None);
+    assert_eq!(config.get_value("short"), Some("abc 123"));
+    
+    // Invalid hex not detected as hash
+    assert_eq!(config.get_hash("invalid-hash"), None);
+    assert_eq!(config.get_value("invalid-hash"), Some("ghijkl 456"));
+}
+
+#[test]
+fn test_hash_pair_struct() {
+    let config_text = r#"
+test-hash = fedcba9876543210 123456
+    "#;
+    
+    let config = ConfigFile::parse(config_text).unwrap();
+    let hash_pair = config.get_hash_pair("test-hash").unwrap();
+    
+    assert_eq!(hash_pair.hash, "fedcba9876543210");
+    assert_eq!(hash_pair.size, 123456);
+}

--- a/tact-parser/tests/encoding_tests.rs
+++ b/tact-parser/tests/encoding_tests.rs
@@ -1,0 +1,230 @@
+//! Integration tests for encoding file parsing
+
+use tact_parser::encoding::EncodingFile;
+use tact_parser::utils::write_uint40;
+
+/// Helper to create a test encoding file with given entries
+fn create_test_encoding_file(entries: Vec<(Vec<u8>, Vec<Vec<u8>>, u64)>) -> Vec<u8> {
+    let mut data = Vec::new();
+    
+    // Magic "EN"
+    data.extend_from_slice(&[0x45, 0x4E]);
+    // Version 1
+    data.push(1);
+    // Hash sizes
+    data.push(16); // CKey hash size
+    data.push(16); // EKey hash size
+    
+    // Calculate page size needed (at least big enough for our entries)
+    let entries_size = entries.iter()
+        .map(|(ckey, ekeys, _size)| 1 + 5 + ckey.len() + ekeys.len() * ekeys[0].len())
+        .sum::<usize>();
+    let page_size_kb = ((entries_size + 1023) / 1024).max(1) as u16;
+    
+    // Page sizes (big-endian!)
+    data.extend_from_slice(&page_size_kb.to_be_bytes()); // CKey page size
+    data.extend_from_slice(&page_size_kb.to_be_bytes()); // EKey page size
+    
+    // Page counts (big-endian!)
+    let page_count: u32 = if entries.is_empty() { 0 } else { 1 };
+    data.extend_from_slice(&page_count.to_be_bytes()); // CKey page count
+    data.extend_from_slice(&0u32.to_be_bytes()); // EKey page count (simplified)
+    
+    // Unknown field
+    data.push(0);
+    // ESpec block size (big-endian!)
+    data.extend_from_slice(&0u32.to_be_bytes());
+    
+    if !entries.is_empty() {
+        // CKey page table entry
+        // First hash (just use zeros)
+        data.extend_from_slice(&[0u8; 16]);
+        // Checksum (simplified - just zeros)
+        data.extend_from_slice(&[0u8; 16]);
+        
+        // Build CKey page
+        let mut page_data = Vec::new();
+        for (ckey, ekeys, size) in &entries {
+            // Key count
+            page_data.push(ekeys.len() as u8);
+            // File size (40-bit)
+            page_data.extend_from_slice(&write_uint40(*size));
+            // CKey
+            page_data.extend_from_slice(ckey);
+            // EKeys
+            for ekey in ekeys {
+                page_data.extend_from_slice(ekey);
+            }
+        }
+        
+        // Pad to page size
+        let page_size = page_size_kb as usize * 1024;
+        page_data.resize(page_size, 0);
+        
+        data.extend_from_slice(&page_data);
+    }
+    
+    data
+}
+
+#[test]
+fn test_encoding_file_with_entries() {
+    // Create test CKeys and EKeys
+    let ckey1 = vec![1u8; 16];
+    let ekey1 = vec![2u8; 16];
+    let ekey2 = vec![3u8; 16];
+    
+    let ckey2 = vec![4u8; 16];
+    let ekey3 = vec![5u8; 16];
+    
+    let entries = vec![
+        (ckey1.clone(), vec![ekey1.clone(), ekey2.clone()], 1000),
+        (ckey2.clone(), vec![ekey3.clone()], 2000),
+    ];
+    
+    let data = create_test_encoding_file(entries);
+    let encoding = EncodingFile::parse(&data).unwrap();
+    
+    // Test CKey → EKey lookup
+    let entry1 = encoding.lookup_by_ckey(&ckey1).unwrap();
+    assert_eq!(entry1.encoding_keys.len(), 2);
+    assert_eq!(entry1.encoding_keys[0], ekey1);
+    assert_eq!(entry1.encoding_keys[1], ekey2);
+    assert_eq!(entry1.size, 1000);
+    
+    let entry2 = encoding.lookup_by_ckey(&ckey2).unwrap();
+    assert_eq!(entry2.encoding_keys.len(), 1);
+    assert_eq!(entry2.encoding_keys[0], ekey3);
+    assert_eq!(entry2.size, 2000);
+    
+    // Test EKey → CKey reverse lookup
+    assert_eq!(encoding.lookup_by_ekey(&ekey1), Some(&ckey1));
+    assert_eq!(encoding.lookup_by_ekey(&ekey2), Some(&ckey1));
+    assert_eq!(encoding.lookup_by_ekey(&ekey3), Some(&ckey2));
+    
+    // Test helper methods
+    assert_eq!(encoding.get_ekey_for_ckey(&ckey1), Some(&ekey1));
+    assert_eq!(encoding.get_file_size(&ckey1), Some(1000));
+    assert_eq!(encoding.get_file_size(&ckey2), Some(2000));
+    
+    // Test counts
+    assert_eq!(encoding.ckey_count(), 2);
+    assert_eq!(encoding.ekey_count(), 3);
+}
+
+#[test]
+fn test_encoding_file_large_sizes() {
+    // Test 40-bit integer support with large file sizes
+    let ckey = vec![0xAAu8; 16];
+    let ekey = vec![0xBBu8; 16];
+    let large_size = 0xFF_FFFF_FFFF; // Max 40-bit value
+    
+    let entries = vec![(ckey.clone(), vec![ekey.clone()], large_size)];
+    let data = create_test_encoding_file(entries);
+    let encoding = EncodingFile::parse(&data).unwrap();
+    
+    assert_eq!(encoding.get_file_size(&ckey), Some(large_size));
+}
+
+#[test]
+fn test_encoding_file_empty_lookup() {
+    let data = create_test_encoding_file(vec![]);
+    let encoding = EncodingFile::parse(&data).unwrap();
+    
+    let nonexistent_key = vec![0xFFu8; 16];
+    assert!(encoding.lookup_by_ckey(&nonexistent_key).is_none());
+    assert!(encoding.lookup_by_ekey(&nonexistent_key).is_none());
+    assert_eq!(encoding.get_ekey_for_ckey(&nonexistent_key), None);
+    assert_eq!(encoding.get_file_size(&nonexistent_key), None);
+}
+
+#[test]
+fn test_encoding_header_endianness() {
+    // This test verifies that we're correctly handling big-endian values
+    let mut data = Vec::new();
+    
+    // Magic "EN"
+    data.extend_from_slice(&[0x45, 0x4E]);
+    // Version 1
+    data.push(1);
+    // Hash sizes
+    data.push(16);
+    data.push(16);
+    
+    // These values should be read as big-endian
+    // 0x1234 in big-endian = [0x12, 0x34]
+    data.extend_from_slice(&[0x12, 0x34]); // CKey page size = 4660 KB
+    data.extend_from_slice(&[0x56, 0x78]); // EKey page size = 22136 KB
+    
+    // Page counts set to 0 for header-only test
+    data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // CKey page count = 0  
+    data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // EKey page count = 0
+    
+    data.push(0); // Unknown
+    data.extend_from_slice(&[0x11, 0x22, 0x33, 0x44]); // ESpec block size
+    
+    let encoding = EncodingFile::parse(&data).unwrap();
+    
+    assert_eq!(encoding.header.ckey_page_size_kb, 0x1234);
+    assert_eq!(encoding.header.ekey_page_size_kb, 0x5678);
+    assert_eq!(encoding.header.ckey_page_count, 0);
+    assert_eq!(encoding.header.ekey_page_count, 0);
+    assert_eq!(encoding.header.espec_block_size, 0x11223344);
+}
+
+#[test]
+fn test_multiple_ekeys_per_ckey() {
+    // Some content can have multiple encoding keys (different compression methods)
+    let ckey = vec![0x11u8; 16];
+    let ekeys = vec![
+        vec![0x21u8; 16],
+        vec![0x22u8; 16],
+        vec![0x23u8; 16],
+        vec![0x24u8; 16],
+    ];
+    
+    let entries = vec![(ckey.clone(), ekeys.clone(), 5000)];
+    let data = create_test_encoding_file(entries);
+    let encoding = EncodingFile::parse(&data).unwrap();
+    
+    let entry = encoding.lookup_by_ckey(&ckey).unwrap();
+    assert_eq!(entry.encoding_keys.len(), 4);
+    
+    // All EKeys should map back to the same CKey
+    for ekey in &ekeys {
+        assert_eq!(encoding.lookup_by_ekey(ekey), Some(&ckey));
+    }
+    
+    // First EKey should be returned by helper
+    assert_eq!(encoding.get_ekey_for_ckey(&ckey), Some(&ekeys[0]));
+}
+
+#[test]
+fn test_40bit_integer_in_encoding() {
+    // Test various 40-bit integer values
+    let test_sizes = vec![
+        0,                  // Minimum
+        0xFF,               // 1 byte max
+        0xFFFF,             // 2 bytes max
+        0xFFFFFF,           // 3 bytes max
+        0xFFFFFFFF,         // 4 bytes max
+        0x1234567890,       // Arbitrary 40-bit value
+        0xFFFFFFFFFF,       // Maximum 40-bit value
+    ];
+    
+    for (i, &size) in test_sizes.iter().enumerate() {
+        let ckey = vec![i as u8; 16];
+        let ekey = vec![(i + 100) as u8; 16];
+        
+        let entries = vec![(ckey.clone(), vec![ekey.clone()], size)];
+        let data = create_test_encoding_file(entries);
+        let encoding = EncodingFile::parse(&data).unwrap();
+        
+        assert_eq!(
+            encoding.get_file_size(&ckey),
+            Some(size),
+            "Failed for size {:#x}",
+            size
+        );
+    }
+}

--- a/tact-parser/tests/install_tests.rs
+++ b/tact-parser/tests/install_tests.rs
@@ -1,0 +1,285 @@
+//! Integration tests for install manifest parsing
+
+use tact_parser::install::{InstallManifest, Platform};
+
+/// Helper to create a test install manifest
+fn create_test_install_manifest(
+    tags: Vec<(&str, u16, Vec<bool>)>,
+    entries: Vec<(&str, Vec<u8>, u32)>,
+) -> Vec<u8> {
+    let mut data = Vec::new();
+    
+    // Magic "IN"
+    data.extend_from_slice(&[0x49, 0x4E]);
+    // Version 1
+    data.push(1);
+    // Hash size
+    data.push(16);
+    // Tag count (big-endian!)
+    data.extend_from_slice(&(tags.len() as u16).to_be_bytes());
+    // Entry count (big-endian!)
+    data.extend_from_slice(&(entries.len() as u32).to_be_bytes());
+    
+    // Tags
+    let bytes_per_tag = (entries.len() + 7) / 8;
+    for (name, tag_type, mask) in &tags {
+        // Tag name (null-terminated)
+        data.extend_from_slice(name.as_bytes());
+        data.push(0);
+        // Tag type (big-endian!)
+        data.extend_from_slice(&(*tag_type).to_be_bytes());
+        // Bitmask
+        let mut mask_bytes = vec![0u8; bytes_per_tag];
+        for (i, &has_tag) in mask.iter().enumerate() {
+            if has_tag {
+                mask_bytes[i / 8] |= 1 << (i % 8);
+            }
+        }
+        data.extend_from_slice(&mask_bytes);
+    }
+    
+    // Entries
+    for (path, ckey, size) in &entries {
+        // Path (null-terminated)
+        data.extend_from_slice(path.as_bytes());
+        data.push(0);
+        // CKey
+        data.extend_from_slice(ckey);
+        // Size (big-endian!)
+        data.extend_from_slice(&size.to_be_bytes());
+    }
+    
+    data
+}
+
+#[test]
+fn test_multi_platform_install() {
+    // Create a manifest with Windows, Mac, and shared files
+    let tags = vec![
+        ("Windows", 0x01, vec![true, false, true, true]),    // Files 0, 2, 3
+        ("OSX", 0x02, vec![false, true, true, false]),       // Files 1, 2
+        ("enUS", 0x04, vec![true, true, true, true]),        // All files
+    ];
+    
+    let entries = vec![
+        ("game.exe", vec![1u8; 16], 1000),          // Windows only
+        ("game.app", vec![2u8; 16], 2000),          // Mac only
+        ("data/shared.dat", vec![3u8; 16], 3000),   // Both platforms
+        ("win64.dll", vec![4u8; 16], 4000),         // Windows only
+    ];
+    
+    let data = create_test_install_manifest(tags, entries);
+    let manifest = InstallManifest::parse(&data).unwrap();
+    
+    // Test platform filtering
+    let windows_files = manifest.get_files_for_platform(Platform::Windows);
+    assert_eq!(windows_files.len(), 3);
+    assert!(windows_files.iter().any(|f| f.path == "game.exe"));
+    assert!(windows_files.iter().any(|f| f.path == "data/shared.dat"));
+    assert!(windows_files.iter().any(|f| f.path == "win64.dll"));
+    
+    let mac_files = manifest.get_files_for_platform(Platform::Mac);
+    assert_eq!(mac_files.len(), 2);
+    assert!(mac_files.iter().any(|f| f.path == "game.app"));
+    assert!(mac_files.iter().any(|f| f.path == "data/shared.dat"));
+    
+    // Test size calculations
+    assert_eq!(manifest.calculate_size_for_platform(Platform::Windows), 8000); // 1000 + 3000 + 4000
+    assert_eq!(manifest.calculate_size_for_platform(Platform::Mac), 5000);     // 2000 + 3000
+    assert_eq!(manifest.calculate_size_for_platform(Platform::All), 10000);    // All files
+    
+    // Test tag combinations
+    let windows_enus = manifest.get_files_for_tags(&["Windows", "enUS"]);
+    assert_eq!(windows_enus.len(), 3); // Windows files that also have enUS
+    
+    // Test getting all tags
+    let all_tags = manifest.get_all_tags();
+    assert!(all_tags.contains(&"Windows"));
+    assert!(all_tags.contains(&"OSX"));
+    assert!(all_tags.contains(&"enUS"));
+}
+
+#[test]
+fn test_locale_specific_files() {
+    // Create a manifest with locale-specific files
+    let tags = vec![
+        ("enUS", 0x01, vec![true, false, false, true]),
+        ("deDE", 0x02, vec![false, true, false, true]),
+        ("frFR", 0x04, vec![false, false, true, true]),
+        ("Common", 0x08, vec![false, false, false, true]),
+    ];
+    
+    let entries = vec![
+        ("locale/enUS/strings.db", vec![1u8; 16], 100),
+        ("locale/deDE/strings.db", vec![2u8; 16], 110),
+        ("locale/frFR/strings.db", vec![3u8; 16], 120),
+        ("data/common.dat", vec![4u8; 16], 5000),
+    ];
+    
+    let data = create_test_install_manifest(tags, entries);
+    let manifest = InstallManifest::parse(&data).unwrap();
+    
+    // Test locale-specific queries
+    let enus_files = manifest.get_files_for_tags(&["enUS"]);
+    assert_eq!(enus_files.len(), 2);
+    assert!(enus_files.iter().any(|f| f.path == "locale/enUS/strings.db"));
+    assert!(enus_files.iter().any(|f| f.path == "data/common.dat"));
+    
+    let dede_files = manifest.get_files_for_tags(&["deDE"]);
+    assert_eq!(dede_files.len(), 2);
+    assert!(dede_files.iter().any(|f| f.path == "locale/deDE/strings.db"));
+    
+    // Calculate size for specific locale
+    assert_eq!(manifest.calculate_size_for_tags(&["enUS"]), 5100);
+    assert_eq!(manifest.calculate_size_for_tags(&["deDE"]), 5110);
+    assert_eq!(manifest.calculate_size_for_tags(&["frFR"]), 5120);
+    
+    // Common files only
+    let common_only = manifest.get_files_for_tags(&["Common"]);
+    assert_eq!(common_only.len(), 1);
+    assert_eq!(common_only[0].path, "data/common.dat");
+}
+
+#[test]
+fn test_get_file_by_path() {
+    let tags = vec![
+        ("All", 0x01, vec![true, true, true]),
+    ];
+    
+    let entries = vec![
+        ("file1.dat", vec![1u8; 16], 1000),
+        ("dir/file2.dat", vec![2u8; 16], 2000),
+        ("dir/subdir/file3.dat", vec![3u8; 16], 3000),
+    ];
+    
+    let data = create_test_install_manifest(tags, entries);
+    let manifest = InstallManifest::parse(&data).unwrap();
+    
+    // Test path lookup
+    let file1 = manifest.get_file_by_path("file1.dat").unwrap();
+    assert_eq!(file1.size, 1000);
+    assert_eq!(file1.ckey, vec![1u8; 16]);
+    
+    let file2 = manifest.get_file_by_path("dir/file2.dat").unwrap();
+    assert_eq!(file2.size, 2000);
+    
+    let file3 = manifest.get_file_by_path("dir/subdir/file3.dat").unwrap();
+    assert_eq!(file3.size, 3000);
+    
+    // Test nonexistent file
+    assert!(manifest.get_file_by_path("nonexistent.dat").is_none());
+}
+
+#[test]
+fn test_complex_tag_combinations() {
+    // Test with many overlapping tags
+    let tags = vec![
+        ("A", 0x01, vec![true, true, false, false]),
+        ("B", 0x02, vec![true, false, true, false]),
+        ("C", 0x04, vec![true, false, false, true]),
+        ("D", 0x08, vec![false, true, true, true]),
+    ];
+    
+    let entries = vec![
+        ("file_abc.dat", vec![1u8; 16], 1000),  // Tags: A, B, C
+        ("file_ad.dat", vec![2u8; 16], 2000),   // Tags: A, D
+        ("file_bd.dat", vec![3u8; 16], 3000),   // Tags: B, D
+        ("file_cd.dat", vec![4u8; 16], 4000),   // Tags: C, D
+    ];
+    
+    let data = create_test_install_manifest(tags, entries);
+    let manifest = InstallManifest::parse(&data).unwrap();
+    
+    // Test single tag queries
+    assert_eq!(manifest.get_files_for_tags(&["A"]).len(), 2);
+    assert_eq!(manifest.get_files_for_tags(&["B"]).len(), 2);
+    assert_eq!(manifest.get_files_for_tags(&["C"]).len(), 2);
+    assert_eq!(manifest.get_files_for_tags(&["D"]).len(), 3);
+    
+    // Test multiple tag requirements (AND logic)
+    assert_eq!(manifest.get_files_for_tags(&["A", "B"]).len(), 1); // Only file_abc.dat
+    assert_eq!(manifest.get_files_for_tags(&["A", "C"]).len(), 1); // Only file_abc.dat
+    assert_eq!(manifest.get_files_for_tags(&["B", "D"]).len(), 1); // Only file_bd.dat
+    assert_eq!(manifest.get_files_for_tags(&["C", "D"]).len(), 1); // Only file_cd.dat
+    
+    // Test impossible combinations
+    assert_eq!(manifest.get_files_for_tags(&["A", "B", "D"]).len(), 0);
+}
+
+#[test]
+fn test_large_manifest() {
+    // Test with many files to ensure bitmask calculation works correctly
+    let num_files = 100;
+    let mut tag_mask = vec![false; num_files];
+    
+    // Mark every other file
+    for i in (0..num_files).step_by(2) {
+        tag_mask[i] = true;
+    }
+    
+    let tags = vec![
+        ("EvenFiles", 0x01, tag_mask.clone()),
+    ];
+    
+    let mut owned_entries = Vec::new();
+    for i in 0..num_files {
+        let path = format!("file_{:03}.dat", i);
+        let ckey = vec![i as u8; 16];
+        let size = (i * 100) as u32;
+        owned_entries.push((path, ckey, size));
+    }
+    
+    // Create the manifest data
+    let mut data = Vec::new();
+    data.extend_from_slice(&[0x49, 0x4E]);
+    data.push(1);
+    data.push(16);
+    data.extend_from_slice(&(tags.len() as u16).to_be_bytes());
+    data.extend_from_slice(&(num_files as u32).to_be_bytes());
+    
+    // Tags
+    let bytes_per_tag = (num_files + 7) / 8;
+    for (name, tag_type, mask) in &tags {
+        data.extend_from_slice(name.as_bytes());
+        data.push(0);
+        let tag_type_u16: u16 = *tag_type;
+        data.extend_from_slice(&tag_type_u16.to_be_bytes());
+        let mut mask_bytes = vec![0u8; bytes_per_tag];
+        for (i, &has_tag) in mask.iter().enumerate() {
+            if has_tag {
+                mask_bytes[i / 8] |= 1 << (i % 8);
+            }
+        }
+        data.extend_from_slice(&mask_bytes);
+    }
+    
+    // Entries
+    for (path, ckey, size) in &owned_entries {
+        data.extend_from_slice(path.as_bytes());
+        data.push(0);
+        data.extend_from_slice(ckey);
+        data.extend_from_slice(&size.to_be_bytes());
+    }
+    
+    let manifest = InstallManifest::parse(&data).unwrap();
+    
+    // Check that we have the right number of entries
+    assert_eq!(manifest.entries.len(), num_files);
+    
+    // Check that exactly half have the tag
+    let even_files = manifest.get_files_for_tags(&["EvenFiles"]);
+    assert_eq!(even_files.len(), num_files / 2);
+    
+    // Verify specific files
+    for i in 0..num_files {
+        let path = format!("file_{:03}.dat", i);
+        let file = manifest.get_file_by_path(&path).unwrap();
+        assert_eq!(file.size, (i * 100) as u32);
+        
+        if i % 2 == 0 {
+            assert!(file.tags.contains(&"EvenFiles".to_string()));
+        } else {
+            assert!(!file.tags.contains(&"EvenFiles".to_string()));
+        }
+    }
+}


### PR DESCRIPTION



## 🤖 New release

* `ngdp-cdn`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `ribbit-client`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `tact-client`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `ngdp-cache`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `tact-parser`: 0.1.0
* `ngdp-client`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `ribbit-client` breaking changes

```text
--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_missing.ron

Failed in:
  method from_bpsv of trait TypedResponse, previously in file /tmp/.tmpsiNj00/ribbit-client/src/response_types.rs:15
  method from_bpsv of trait TypedResponse, previously in file /tmp/.tmpsiNj00/ribbit-client/src/response_types.rs:15
```

### ⚠ `ngdp-client` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field parse_config of variant ProductsCommands::Versions in /tmp/.tmp9PNzOt/cascette-rs/ngdp-client/src/lib.rs:57
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `ngdp-cdn`

<blockquote>

## [0.2.2](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cdn-v0.2.1...ngdp-cdn-v0.2.2) - 2025-08-06

### Other

- ✨ feat: integrate tact-parser with build configuration analysis
- 📝 docs: update changelogs and add module documentation
- 🚨 fix: remove panicking Default impls and fix unwrap() calls

### Fixed

- **Removed panicking Default implementation**:
  - Removed `Default` trait implementation that would panic on failure
  - The implementation was not used anywhere in the codebase

- **Code optimization**:
  - Removed unnecessary string clones in parallel download operations
  - Replaced `vec!` with array for fixed-size test data
  - Removed redundant `to_string()` calls in fallback implementation
</blockquote>

## `ribbit-client`

<blockquote>

## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.1.2...ribbit-client-v0.2.0) - 2025-08-06

### Other

- 📝 docs: update changelogs and add module documentation
- Merge pull request #11 from micolous/refactor/bpsv-response
- re-export TypedBpsvResponse
- Allow non-BPSV responses to be parsed

### Changed

- Refactored BPSV response handling:
  - Split BPSV functionality from `TypedResponse` to new `TypedBpsvResponse` trait
  - Allows non-BPSV responses to be parsed through the typed response system
  - Re-exported `TypedBpsvResponse` for backward compatibility
  - Improved separation of concerns between response types
</blockquote>

## `tact-client`

<blockquote>

## [0.1.3](https://github.com/wowemulation-dev/cascette-rs/compare/tact-client-v0.1.2...tact-client-v0.1.3) - 2025-08-06

### Other

- ✨ feat: integrate tact-parser with build configuration analysis
- 📝 docs: update changelogs and add module documentation
- 🚨 fix: remove panicking Default impls and fix unwrap() calls

### Fixed

- **Replaced unwrap() calls with proper error handling**:
  - All response parsing now uses `ok_or_else()` with meaningful error messages
  - Added proper error propagation for missing fields in BPSV responses
  - Prevents potential panics when parsing malformed responses
</blockquote>

## `ngdp-cache`

<blockquote>

## [0.1.4](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.3...ngdp-cache-v0.1.4) - 2025-08-06

### Fixed

- path tests on non-linux platforms

### Other

- ✨ feat: integrate tact-parser with build configuration analysis
- 📝 docs: update changelogs and add module documentation
- Merge pull request #11 from micolous/refactor/bpsv-response
- Merge pull request #10 from micolous/fix/non-linux-paths

### Fixed

- Fixed path tests on non-Linux platforms:
  - Updated cache path tests to work correctly across different operating systems
  - Fixed hardcoded Unix path separators that caused test failures on Windows
</blockquote>


## `ngdp-client`

<blockquote>

## [0.3.0](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.2.0...ngdp-client-v0.3.0) - 2025-08-06

### Other

- ✨ feat: integrate tact-parser with build configuration analysis
- 📝 docs: update changelogs and add module documentation
- 🎨 style: optimize code and remove unnecessary allocations

### Added

- **TACT parser integration for build configuration analysis**:
  - Added `inspect build-config` command for detailed build configuration analysis
  - Downloads and parses real build configurations from CDN using tact-parser crate
  - Visual tree representation of game build structure with emoji and Unicode box-drawing
  - Shows core game files (root, encoding, install, download, size) with file sizes
  - Displays build information (version, UID, product, installer)
  - Patch status indication with hash display
  - VFS (Virtual File System) entries listing with file counts
  - Support for all output formats: text (visual tree), JSON, and raw BPSV
  - Example: `ngdp inspect build-config wow_classic_era 61582 --region us`

- **Enhanced products versions command with build configuration parsing**:
  - Added `--parse-config` flag to `products versions` command
  - Downloads and parses build configurations to show meaningful information
  - Displays build names instead of just cryptic hashes (e.g., "WOW-62417patch11.2.0_Retail")
  - Shows patch availability and file size information  
  - Counts VFS entries to indicate build complexity
  - Maintains full backward compatibility when flag is not used
  - Works across all WoW products (wow, wow_classic_era, wowt, etc.)
  - Example: `ngdp products versions wow --parse-config`

- **Dependencies**:
  - Added `tact-parser` (0.1.0) dependency for TACT file format parsing
  - Added `ngdp-cdn` client integration for downloading build configurations

### Fixed

- **Code optimization**:
  - Optimized string building in certificate PEM to DER conversion using iterator chains
  - More efficient and idiomatic implementation of base64 extraction
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).