### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "blte"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "byteorder",
  "flate2",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-cache"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "criterion",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-cdn"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "criterion",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-crypto"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cipher",
  "criterion",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "ribbit-client"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "asn1",
  "base64",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "tact-client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "criterion",
  "ngdp-bpsv",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "tact-parser"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "blte",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Daniel S. Reichenbach <daniel@kogit.network>"]
 edition = "2024"
 rust-version = "1.86"

--- a/blte/CHANGELOG.md
+++ b/blte/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/blte-v0.1.0...blte-v0.2.0) - 2025-08-06
+
+### Added
+
+- complete TACT parser implementation with encryption and BLTE support

--- a/ngdp-cache/CHANGELOG.md
+++ b/ngdp-cache/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.3...ngdp-cache-v0.1.4) - 2025-08-06
+
+### Fixed
+
+- path tests on non-linux platforms
+
+### Other
+
+- ✨ feat: integrate tact-parser with build configuration analysis
+- 📝 docs: update changelogs and add module documentation
+- Merge pull request #11 from micolous/refactor/bpsv-response
+- Merge pull request #10 from micolous/fix/non-linux-paths
+
 ### Fixed
 
 - Fixed path tests on non-Linux platforms:

--- a/ngdp-cache/Cargo.toml
+++ b/ngdp-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-cache"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,12 +15,12 @@ categories = ["caching", "filesystem", "games"]
 bytes = "1.8"
 dirs = { workspace = true }
 futures = "0.3"
-ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.1" }
+ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.2" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-ribbit-client = { path = "../ribbit-client", version = "0.1.2" }
+ribbit-client = { path = "../ribbit-client", version = "0.2.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
-tact-client = { path = "../tact-client", version = "0.1.2" }
+tact-client = { path = "../tact-client", version = "0.1.3" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
 tracing = { workspace = true }

--- a/ngdp-cdn/CHANGELOG.md
+++ b/ngdp-cdn/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cdn-v0.2.1...ngdp-cdn-v0.2.2) - 2025-08-06
+
+### Other
+
+- ✨ feat: integrate tact-parser with build configuration analysis
+- 📝 docs: update changelogs and add module documentation
+- 🚨 fix: remove panicking Default impls and fix unwrap() calls
+
 ### Fixed
 
 - **Removed panicking Default implementation**:

--- a/ngdp-cdn/Cargo.toml
+++ b/ngdp-cdn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-cdn"
-version = "0.2.1"
+version = "0.2.2"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/ngdp-client/CHANGELOG.md
+++ b/ngdp-client/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.2.0...ngdp-client-v0.3.0) - 2025-08-06
+
+### Added
+
+- complete TACT parser implementation with encryption and BLTE support
+
+### Other
+
+- ✨ feat: integrate tact-parser with build configuration analysis
+- 📝 docs: update changelogs and add module documentation
+- 🎨 style: optimize code and remove unnecessary allocations
+
 ### Added
 
 - **TACT parser integration for build configuration analysis**:

--- a/ngdp-client/Cargo.toml
+++ b/ngdp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-client"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -23,14 +23,14 @@ path = "src/main.rs"
 clap = { workspace = true, features = ["derive", "cargo", "env"] }
 comfy-table = "7.1.1"
 owo-colors = { version = "4.2.1", features = ["supports-colors"] }
-ribbit-client = { path = "../ribbit-client", version = "0.1.2" }
-tact-client = { path = "../tact-client", version = "0.1.2" }
+ribbit-client = { path = "../ribbit-client", version = "0.2.0" }
+tact-client = { path = "../tact-client", version = "0.1.3" }
 ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.1.2" }
-ngdp-cache = { path = "../ngdp-cache", version = "0.1.3" }
-ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.1" }
-tact-parser = { path = "../tact-parser", version = "0.1.0" }
-blte = { path = "../blte", version = "0.1.0" }
-ngdp-crypto = { path = "../ngdp-crypto", version = "0.1.0" }
+ngdp-cache = { path = "../ngdp-cache", version = "0.1.4" }
+ngdp-cdn = { path = "../ngdp-cdn", version = "0.2.2" }
+tact-parser = { path = "../tact-parser", version = "0.2.0" }
+blte = { path = "../blte", version = "0.2.0" }
+ngdp-crypto = { path = "../ngdp-crypto", version = "0.2.0" }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/ngdp-crypto/CHANGELOG.md
+++ b/ngdp-crypto/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-crypto-v0.1.0...ngdp-crypto-v0.2.0) - 2025-08-06
+
+### Added
+
+- complete TACT parser implementation with encryption and BLTE support

--- a/ribbit-client/CHANGELOG.md
+++ b/ribbit-client/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.1.2...ribbit-client-v0.2.0) - 2025-08-06
+
+### Other
+
+- 📝 docs: update changelogs and add module documentation
+- Merge pull request #11 from micolous/refactor/bpsv-response
+- re-export TypedBpsvResponse
+- Allow non-BPSV responses to be parsed
+
 ### Changed
 
 - Refactored BPSV response handling:

--- a/ribbit-client/Cargo.toml
+++ b/ribbit-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ribbit-client"
-version = "0.1.2"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/tact-client/CHANGELOG.md
+++ b/tact-client/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/wowemulation-dev/cascette-rs/compare/tact-client-v0.1.2...tact-client-v0.1.3) - 2025-08-06
+
+### Other
+
+- ✨ feat: integrate tact-parser with build configuration analysis
+- 📝 docs: update changelogs and add module documentation
+- 🚨 fix: remove panicking Default impls and fix unwrap() calls
+
 ### Fixed
 
 - **Replaced unwrap() calls with proper error handling**:

--- a/tact-client/Cargo.toml
+++ b/tact-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact-client"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/tact-parser/CHANGELOG.md
+++ b/tact-parser/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/tact-parser-v0.1.0...tact-parser-v0.2.0) - 2025-08-06
+
+### Added
+
+- complete TACT parser implementation with encryption and BLTE support
+
+### Fixed
+
+- clippy/fmt
+
+### Other
+
+- ✨ feat: integrate tact-parser with build configuration analysis
+- 📝 docs: update changelogs and add module documentation
+- 🎨 style: optimize code and remove unnecessary allocations
+- 🚨 fix: remove panicking Default impls and fix unwrap() calls
+- Move tact-parser dependencies into workspace
+- fmt
+- tidy up old stuff
+- Implement support for pre-8.2 roots
+- Use bufread to improve performance
+- Docs
+- fmt
+- Move all the tests into separate files like the rest of the packages
+- Sort ReadInt implementations
+- Initial wow TACT root parser
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 


### PR DESCRIPTION



## 🤖 New release

* `ngdp-cdn`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `ribbit-client`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `tact-client`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `ngdp-cache`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `ngdp-crypto`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `blte`: 0.1.0 -> 0.2.0
* `tact-parser`: 0.1.0 -> 0.2.0
* `ngdp-client`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `ribbit-client` breaking changes

```text
--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_missing.ron

Failed in:
  method from_bpsv of trait TypedResponse, previously in file /tmp/.tmpuPG52A/ribbit-client/src/response_types.rs:15
  method from_bpsv of trait TypedResponse, previously in file /tmp/.tmpuPG52A/ribbit-client/src/response_types.rs:15
```

### ⚠ `ngdp-crypto` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant CryptoError:InvalidParameter in /tmp/.tmp0ksZhX/cascette-rs/ngdp-crypto/src/error.rs:42
  variant CryptoError:InitializationFailed in /tmp/.tmp0ksZhX/cascette-rs/ngdp-crypto/src/error.rs:46
  variant CryptoError:InvalidParameter in /tmp/.tmp0ksZhX/cascette-rs/ngdp-crypto/src/error.rs:42
  variant CryptoError:InitializationFailed in /tmp/.tmp0ksZhX/cascette-rs/ngdp-crypto/src/error.rs:46
```

### ⚠ `ngdp-client` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field product of variant InspectCommands::Encoding in /tmp/.tmp0ksZhX/cascette-rs/ngdp-client/src/lib.rs:227
  field region of variant InspectCommands::Encoding in /tmp/.tmp0ksZhX/cascette-rs/ngdp-client/src/lib.rs:231
  field search of variant InspectCommands::Encoding in /tmp/.tmp0ksZhX/cascette-rs/ngdp-client/src/lib.rs:239
  field limit of variant InspectCommands::Encoding in /tmp/.tmp0ksZhX/cascette-rs/ngdp-client/src/lib.rs:243
  field parse_config of variant ProductsCommands::Versions in /tmp/.tmp0ksZhX/cascette-rs/ngdp-client/src/lib.rs:57

--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field file of variant InspectCommands::Encoding, previously in file /tmp/.tmpuPG52A/ngdp-client/src/lib.rs:223

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant InspectCommands:Install in /tmp/.tmp0ksZhX/cascette-rs/ngdp-client/src/lib.rs:247
  variant InspectCommands:DownloadManifest in /tmp/.tmp0ksZhX/cascette-rs/ngdp-client/src/lib.rs:265
  variant InspectCommands:Size in /tmp/.tmp0ksZhX/cascette-rs/ngdp-client/src/lib.rs:283
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `ngdp-cdn`

<blockquote>

## [0.2.2](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cdn-v0.2.1...ngdp-cdn-v0.2.2) - 2025-08-06

### Other

- ✨ feat: integrate tact-parser with build configuration analysis
- 📝 docs: update changelogs and add module documentation
- 🚨 fix: remove panicking Default impls and fix unwrap() calls

### Fixed

- **Removed panicking Default implementation**:
  - Removed `Default` trait implementation that would panic on failure
  - The implementation was not used anywhere in the codebase

- **Code optimization**:
  - Removed unnecessary string clones in parallel download operations
  - Replaced `vec!` with array for fixed-size test data
  - Removed redundant `to_string()` calls in fallback implementation
</blockquote>

## `ribbit-client`

<blockquote>

## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.1.2...ribbit-client-v0.2.0) - 2025-08-06

### Other

- 📝 docs: update changelogs and add module documentation
- Merge pull request #11 from micolous/refactor/bpsv-response
- re-export TypedBpsvResponse
- Allow non-BPSV responses to be parsed

### Changed

- Refactored BPSV response handling:
  - Split BPSV functionality from `TypedResponse` to new `TypedBpsvResponse` trait
  - Allows non-BPSV responses to be parsed through the typed response system
  - Re-exported `TypedBpsvResponse` for backward compatibility
  - Improved separation of concerns between response types
</blockquote>

## `tact-client`

<blockquote>

## [0.1.3](https://github.com/wowemulation-dev/cascette-rs/compare/tact-client-v0.1.2...tact-client-v0.1.3) - 2025-08-06

### Other

- ✨ feat: integrate tact-parser with build configuration analysis
- 📝 docs: update changelogs and add module documentation
- 🚨 fix: remove panicking Default impls and fix unwrap() calls

### Fixed

- **Replaced unwrap() calls with proper error handling**:
  - All response parsing now uses `ok_or_else()` with meaningful error messages
  - Added proper error propagation for missing fields in BPSV responses
  - Prevents potential panics when parsing malformed responses
</blockquote>

## `ngdp-cache`

<blockquote>

## [0.1.4](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.1.3...ngdp-cache-v0.1.4) - 2025-08-06

### Fixed

- path tests on non-linux platforms

### Other

- ✨ feat: integrate tact-parser with build configuration analysis
- 📝 docs: update changelogs and add module documentation
- Merge pull request #11 from micolous/refactor/bpsv-response
- Merge pull request #10 from micolous/fix/non-linux-paths

### Fixed

- Fixed path tests on non-Linux platforms:
  - Updated cache path tests to work correctly across different operating systems
  - Fixed hardcoded Unix path separators that caused test failures on Windows
</blockquote>

## `ngdp-crypto`

<blockquote>

## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-crypto-v0.1.0...ngdp-crypto-v0.2.0) - 2025-08-06

### Added

- complete TACT parser implementation with encryption and BLTE support
</blockquote>

## `blte`

<blockquote>

## [0.2.0](https://github.com/wowemulation-dev/cascette-rs/compare/blte-v0.1.0...blte-v0.2.0) - 2025-08-06

### Added

- complete TACT parser implementation with encryption and BLTE support
</blockquote>


## `ngdp-client`

<blockquote>

## [0.3.0](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.2.0...ngdp-client-v0.3.0) - 2025-08-06

### Added

- complete TACT parser implementation with encryption and BLTE support

### Other

- ✨ feat: integrate tact-parser with build configuration analysis
- 📝 docs: update changelogs and add module documentation
- 🎨 style: optimize code and remove unnecessary allocations

### Added

- **TACT parser integration for build configuration analysis**:
  - Added `inspect build-config` command for detailed build configuration analysis
  - Downloads and parses real build configurations from CDN using tact-parser crate
  - Visual tree representation of game build structure with emoji and Unicode box-drawing
  - Shows core game files (root, encoding, install, download, size) with file sizes
  - Displays build information (version, UID, product, installer)
  - Patch status indication with hash display
  - VFS (Virtual File System) entries listing with file counts
  - Support for all output formats: text (visual tree), JSON, and raw BPSV
  - Example: `ngdp inspect build-config wow_classic_era 61582 --region us`

- **Enhanced products versions command with build configuration parsing**:
  - Added `--parse-config` flag to `products versions` command
  - Downloads and parses build configurations to show meaningful information
  - Displays build names instead of just cryptic hashes (e.g., "WOW-62417patch11.2.0_Retail")
  - Shows patch availability and file size information  
  - Counts VFS entries to indicate build complexity
  - Maintains full backward compatibility when flag is not used
  - Works across all WoW products (wow, wow_classic_era, wowt, etc.)
  - Example: `ngdp products versions wow --parse-config`

- **Dependencies**:
  - Added `tact-parser` (0.1.0) dependency for TACT file format parsing
  - Added `ngdp-cdn` client integration for downloading build configurations

### Fixed

- **Code optimization**:
  - Optimized string building in certificate PEM to DER conversion using iterator chains
  - More efficient and idiomatic implementation of base64 extraction
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).