### PR TITLE
chore: release v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "blte"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "byteorder",
  "flate2",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-bpsv"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "serde",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-cache"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "criterion",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-cdn"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "futures-util",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-client"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "ngdp-crypto"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cipher 0.5.0-rc.0",
  "criterion",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "ribbit-client"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "asn1",
  "base64",
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "tact-client"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "ngdp-bpsv",
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "tact-parser"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "blte",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Daniel S. Reichenbach <daniel@kogit.network>"]
 edition = "2024"
 rust-version = "1.86"

--- a/blte/CHANGELOG.md
+++ b/blte/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/blte-v0.3.0...blte-v0.3.1) - 2025-08-07
+
+### Fixed
+
+- resolve clippy uninlined format args warnings
+
+### Other
+
+- update all README files and improve crate descriptions
+# Changelog
+
 All notable changes to the `blte` crate will be documented in this file.
 
 ## [Unreleased]

--- a/blte/Cargo.toml
+++ b/blte/Cargo.toml
@@ -12,7 +12,7 @@ homepage.workspace = true
 [dependencies]
 flate2 = "1.1"
 lz4_flex = "0.11.5"
-ngdp-crypto = { path = "../ngdp-crypto", version = "0.3.0" }
+ngdp-crypto = { path = "../ngdp-crypto", version = "0.3.1" }
 md5 = "0.8"
 tracing.workspace = true
 thiserror.workspace = true

--- a/ngdp-bpsv/CHANGELOG.md
+++ b/ngdp-bpsv/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-bpsv-v0.3.0...ngdp-bpsv-v0.3.1) - 2025-08-07
+
+### Other
+
+- update all README files and improve crate descriptions
+
 ## [0.1.2](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-bpsv-v0.1.1...ngdp-bpsv-v0.1.2) - 2025-07-15
 
 ### Other

--- a/ngdp-bpsv/Cargo.toml
+++ b/ngdp-bpsv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-bpsv"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/ngdp-cache/CHANGELOG.md
+++ b/ngdp-cache/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.3.0...ngdp-cache-v0.3.1) - 2025-08-07
+
+### Other
+
+- update all README files and improve crate descriptions
+
 ### Fixed
 
 - Fixed path tests on non-Linux platforms:

--- a/ngdp-cache/Cargo.toml
+++ b/ngdp-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-cache"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,12 +15,12 @@ categories = ["caching", "filesystem", "games"]
 bytes = "1.10.1"
 dirs = { workspace = true }
 futures = "0.3.31"
-ngdp-cdn = { path = "../ngdp-cdn", version = "0.3.0" }
+ngdp-cdn = { path = "../ngdp-cdn", version = "0.3.1" }
 reqwest = { version = "0.12.22", default-features = false, features = ["rustls-tls"] }
-ribbit-client = { path = "../ribbit-client", version = "0.3.0" }
+ribbit-client = { path = "../ribbit-client", version = "0.3.1" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0.142"
-tact-client = { path = "../tact-client", version = "0.3.0" }
+tact-client = { path = "../tact-client", version = "0.3.1" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
 tracing = { workspace = true }

--- a/ngdp-cdn/CHANGELOG.md
+++ b/ngdp-cdn/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cdn-v0.3.0...ngdp-cdn-v0.3.1) - 2025-08-07
+
+### Other
+
+- update all README files and improve crate descriptions
+
 ### Fixed
 
 - **Removed panicking Default implementation**:

--- a/ngdp-cdn/Cargo.toml
+++ b/ngdp-cdn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-cdn"
-version = "0.3.0"
+version = "0.3.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/ngdp-client/CHANGELOG.md
+++ b/ngdp-client/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.3.0...ngdp-client-v0.3.1) - 2025-08-07
+
+### Fixed
+
+- resolve clippy uninlined format args warnings
+
+### Other
+
+- update all README files and improve crate descriptions
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [0.3.0] - 2025-08-06
 
 ### Added

--- a/ngdp-client/Cargo.toml
+++ b/ngdp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngdp-client"
-version = "0.3.0"
+version = "0.3.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -23,14 +23,14 @@ path = "src/main.rs"
 clap = { workspace = true, features = ["derive", "cargo", "env"] }
 comfy-table = "7.1.4"
 owo-colors = { version = "4.2.2", features = ["supports-colors"] }
-ribbit-client = { path = "../ribbit-client", version = "0.3.0" }
-tact-client = { path = "../tact-client", version = "0.3.0" }
-ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.3.0" }
-ngdp-cache = { path = "../ngdp-cache", version = "0.3.0" }
-ngdp-cdn = { path = "../ngdp-cdn", version = "0.3.0" }
-tact-parser = { path = "../tact-parser", version = "0.3.0" }
-blte = { path = "../blte", version = "0.3.0" }
-ngdp-crypto = { path = "../ngdp-crypto", version = "0.3.0" }
+ribbit-client = { path = "../ribbit-client", version = "0.3.1" }
+tact-client = { path = "../tact-client", version = "0.3.1" }
+ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.3.1" }
+ngdp-cache = { path = "../ngdp-cache", version = "0.3.1" }
+ngdp-cdn = { path = "../ngdp-cdn", version = "0.3.1" }
+tact-parser = { path = "../tact-parser", version = "0.3.1" }
+blte = { path = "../blte", version = "0.3.1" }
+ngdp-crypto = { path = "../ngdp-crypto", version = "0.3.1" }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/ngdp-crypto/CHANGELOG.md
+++ b/ngdp-crypto/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-crypto-v0.3.0...ngdp-crypto-v0.3.1) - 2025-08-07
+
+### Other
+
+- update all README files and improve crate descriptions
+# Changelog
+
 All notable changes to the `ngdp-crypto` crate will be documented in this file.
 
 ## [0.1.0] - 2025-08-06

--- a/ribbit-client/CHANGELOG.md
+++ b/ribbit-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.3.0...ribbit-client-v0.3.1) - 2025-08-07
+
+### Other
+
+- update all README files and improve crate descriptions
+
 ### Changed
 
 - Refactored BPSV response handling:

--- a/ribbit-client/Cargo.toml
+++ b/ribbit-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ribbit-client"
-version = "0.3.0"
+version = "0.3.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ der = "0.7"
 digest = "0.10"
 hex = "0.4"
 mail-parser = "0.11.0"
-ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.3.0" }
+ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.3.1" }
 rand.workspace = true
 rsa = { version = "0.9", features = ["sha2"] }
 sha2 = "0.10"

--- a/tact-client/CHANGELOG.md
+++ b/tact-client/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/tact-client-v0.3.0...tact-client-v0.3.1) - 2025-08-07
+
+### Fixed
+
+- resolve clippy uninlined format args warnings
+
+### Other
+
+- update all README files and improve crate descriptions
+
 ### Fixed
 
 - **Replaced unwrap() calls with proper error handling**:

--- a/tact-client/Cargo.toml
+++ b/tact-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact-client"
-version = "0.3.0"
+version = "0.3.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ categories = [
 ]
 
 [dependencies]
-ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.3.0" }
+ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.3.1" }
 rand.workspace = true
 reqwest = { version = "0.12.22", default-features = false, features = ["rustls-tls", "json", "stream"] }
 thiserror.workspace = true

--- a/tact-parser/CHANGELOG.md
+++ b/tact-parser/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/tact-parser-v0.3.0...tact-parser-v0.3.1) - 2025-08-07
+
+### Other
+
+- update all README files and improve crate descriptions
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/tact-parser/Cargo.toml
+++ b/tact-parser/Cargo.toml
@@ -14,8 +14,8 @@ byteorder.workspace = true
 modular-bitfield.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-blte = { path = "../blte", version = "0.3.0" }
-ngdp-crypto = { path = "../ngdp-crypto", version = "0.3.0" }
+blte = { path = "../blte", version = "0.3.1" }
+ngdp-crypto = { path = "../ngdp-crypto", version = "0.3.1" }
 md5 = "0.8"
 
 [dev-dependencies]
@@ -25,8 +25,8 @@ hex.workspace = true
 tracing-subscriber.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 reqwest = { version = "0.12.22", default-features = false, features = ["rustls-tls"] }
-ribbit-client = { path = "../ribbit-client", version = "0.3.0" }
-ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.3.0" }
+ribbit-client = { path = "../ribbit-client", version = "0.3.1" }
+ngdp-bpsv = { path = "../ngdp-bpsv", version = "0.3.1" }
 
 [[bench]]
 name = "jenkins3"


### PR DESCRIPTION



## 🤖 New release

* `ngdp-bpsv`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `ngdp-cdn`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `ribbit-client`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `tact-client`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `ngdp-cache`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `ngdp-crypto`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `blte`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `tact-parser`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `ngdp-client`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ngdp-bpsv`

<blockquote>

## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-bpsv-v0.3.0...ngdp-bpsv-v0.3.1) - 2025-08-07

### Other

- update all README files and improve crate descriptions
</blockquote>

## `ngdp-cdn`

<blockquote>

## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cdn-v0.3.0...ngdp-cdn-v0.3.1) - 2025-08-07

### Other

- update all README files and improve crate descriptions

### Fixed

- **Removed panicking Default implementation**:
  - Removed `Default` trait implementation that would panic on failure
  - The implementation was not used anywhere in the codebase

- **Code optimization**:
  - Removed unnecessary string clones in parallel download operations
  - Replaced `vec!` with array for fixed-size test data
  - Removed redundant `to_string()` calls in fallback implementation
</blockquote>

## `ribbit-client`

<blockquote>

## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/ribbit-client-v0.3.0...ribbit-client-v0.3.1) - 2025-08-07

### Other

- update all README files and improve crate descriptions

### Changed

- Refactored BPSV response handling:
  - Split BPSV functionality from `TypedResponse` to new `TypedBpsvResponse` trait
  - Allows non-BPSV responses to be parsed through the typed response system
  - Re-exported `TypedBpsvResponse` for backward compatibility
  - Improved separation of concerns between response types
</blockquote>

## `tact-client`

<blockquote>

## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/tact-client-v0.3.0...tact-client-v0.3.1) - 2025-08-07

### Fixed

- resolve clippy uninlined format args warnings

### Other

- update all README files and improve crate descriptions

### Fixed

- **Replaced unwrap() calls with proper error handling**:
  - All response parsing now uses `ok_or_else()` with meaningful error messages
  - Added proper error propagation for missing fields in BPSV responses
  - Prevents potential panics when parsing malformed responses
</blockquote>

## `ngdp-cache`

<blockquote>

## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-cache-v0.3.0...ngdp-cache-v0.3.1) - 2025-08-07

### Other

- update all README files and improve crate descriptions

### Fixed

- Fixed path tests on non-Linux platforms:
  - Updated cache path tests to work correctly across different operating systems
  - Fixed hardcoded Unix path separators that caused test failures on Windows
</blockquote>

## `ngdp-crypto`

<blockquote>

## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-crypto-v0.3.0...ngdp-crypto-v0.3.1) - 2025-08-07

### Other

- update all README files and improve crate descriptions
</blockquote>


## `tact-parser`

<blockquote>

## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/tact-parser-v0.3.0...tact-parser-v0.3.1) - 2025-08-07

### Other

- update all README files and improve crate descriptions
</blockquote>

## `ngdp-client`

<blockquote>

## [0.3.1](https://github.com/wowemulation-dev/cascette-rs/compare/ngdp-client-v0.3.0...ngdp-client-v0.3.1) - 2025-08-07

### Fixed

- resolve clippy uninlined format args warnings

### Other

- update all README files and improve crate descriptions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).