### PR TITLE
fix: add format validation matching Agent.exe constraints

### DIFF
--- a/crates/cascette-formats/src/archive/error.rs
+++ b/crates/cascette-formats/src/archive/error.rs
@@ -100,6 +100,15 @@ pub enum ArchiveError {
     /// Invalid format parameters
     #[error("Invalid format: {0}")]
     InvalidFormat(String),
+
+    /// File size does not match expected size from footer
+    #[error("File size mismatch: expected {expected}, actual {actual}")]
+    FileSizeMismatch {
+        /// Expected file size computed from footer fields
+        expected: u64,
+        /// Actual file size
+        actual: u64,
+    },
 }
 
 impl ArchiveError {

--- a/crates/cascette-formats/src/encoding/error.rs
+++ b/crates/cascette-formats/src/encoding/error.rs
@@ -38,4 +38,32 @@ pub enum EncodingError {
 
     #[error("ESpec table size doesn't match header")]
     InvalidESpecSize,
+
+    #[error("Invalid flags: unk_11 must be 0, got {0}")]
+    InvalidFlags(u8),
+
+    #[error("Invalid {field} hash size: expected 1..=16, got {value}")]
+    InvalidHashSize {
+        /// Which hash size field is invalid
+        field: &'static str,
+        /// The invalid value
+        value: u8,
+    },
+
+    #[error("Invalid {field} page count: must be > 0, got {value}")]
+    InvalidPageCount {
+        /// Which page count field is invalid
+        field: &'static str,
+        /// The invalid value
+        value: u32,
+    },
+
+    #[error("Invalid ESpec block size: must be > 0, got {0}")]
+    InvalidESpecBlockSize(u32),
+
+    #[error("Empty ESpec string found")]
+    EmptyESpec,
+
+    #[error("ESpec block not null-terminated")]
+    UnterminatedESpec,
 }

--- a/crates/cascette-formats/src/encoding/file.rs
+++ b/crates/cascette-formats/src/encoding/file.rs
@@ -193,19 +193,12 @@ impl EncodingFile {
             })?;
 
         // Validate header
-        if header.version != 1 {
-            return Err(EncodingError::UnsupportedVersion(header.version));
-        }
+        header.validate()?;
 
         // Read ESpec table (comes right after header per CASC specification)
-        let espec_table = if header.espec_block_size > 0 {
-            let mut espec_data = vec![0u8; header.espec_block_size as usize];
-            cursor.read_exact(&mut espec_data)?;
-            ESpecTable::parse(&espec_data)?
-        } else {
-            // No ESpec table in header
-            ESpecTable::default()
-        };
+        let mut espec_data = vec![0u8; header.espec_block_size as usize];
+        cursor.read_exact(&mut espec_data)?;
+        let espec_table = ESpecTable::parse(&espec_data)?;
 
         // Read CKey index
         let mut ckey_index = Vec::with_capacity(header.ckey_page_count as usize);

--- a/crates/cascette-formats/src/install/header.rs
+++ b/crates/cascette-formats/src/install/header.rs
@@ -58,7 +58,7 @@ impl InstallHeader {
             return Err(InstallError::InvalidMagic(self.magic));
         }
 
-        if self.version != 1 {
+        if self.version == 0 || self.version > 2 {
             return Err(InstallError::UnsupportedVersion(self.version));
         }
 
@@ -111,12 +111,25 @@ mod tests {
             Err(InstallError::InvalidMagic(_))
         ));
 
-        // Test invalid version
+        // Test version 2 is valid
+        let mut v2_header = valid_header.clone();
+        v2_header.version = 2;
+        assert!(v2_header.validate().is_ok());
+
+        // Test version 0 is invalid
         let mut invalid_version = valid_header.clone();
-        invalid_version.version = 2;
+        invalid_version.version = 0;
         assert!(matches!(
             invalid_version.validate(),
-            Err(InstallError::UnsupportedVersion(2))
+            Err(InstallError::UnsupportedVersion(0))
+        ));
+
+        // Test version 3 is invalid
+        let mut invalid_version = valid_header.clone();
+        invalid_version.version = 3;
+        assert!(matches!(
+            invalid_version.validate(),
+            Err(InstallError::UnsupportedVersion(3))
         ));
 
         // Test invalid ckey length

--- a/crates/cascette-formats/src/install/mod.rs
+++ b/crates/cascette-formats/src/install/mod.rs
@@ -281,7 +281,7 @@ mod tests {
                 let data = manifest.build()?;
                 let parsed = InstallManifest::parse(&data)?;
 
-                // Verify structure
+                // Verify structure (builder produces V1 by default)
                 prop_assert_eq!(parsed.header.version, 1);
                 prop_assert_eq!(parsed.entries.len(), entries.len());
                 prop_assert_eq!(parsed.tags.len(), tags.len());

--- a/crates/cascette-formats/src/patch_archive/error.rs
+++ b/crates/cascette-formats/src/patch_archive/error.rs
@@ -28,6 +28,10 @@ pub enum PatchArchiveError {
     #[error("invalid block size bits: {0}")]
     InvalidBlockSize(u8),
 
+    /// Unsupported flags (e.g. extended header that we cannot parse)
+    #[error("unsupported PA flags: 0x{0:02X}")]
+    UnsupportedFlags(u8),
+
     /// String too long in patch entry
     #[error("string too long in patch entry")]
     StringTooLong,


### PR DESCRIPTION
## Summary

- Add `EncodingHeader::validate()` checking all 8 fields (version, unk_11, hash sizes, page counts, espec block size)
- Reject empty ESpec strings and unterminated ESpec data in `ESpecTable::parse()`
- Support install manifest V2 with per-entry `file_type` byte
- Add `IndexFooter::validate_file_size()` for CDN index expected vs actual file size check
- Add `is_plain_data()` and `has_extended_header()` flag methods to `PatchArchiveHeader`; reject extended header during parsing
- Call `TvfsHeader::validate()` in `TvfsFile::parse()` and `load_from_blte()`

ZBSDIFF1 endianness verification deferred pending real patch data.

## Test plan

- [x] All 604 cascette-formats tests pass (`cargo nextest run -p cascette-formats`)
- [x] Clippy clean (`cargo clippy -p cascette-formats -- -D warnings`)
- [x] Formatting clean (`cargo fmt -p cascette-formats -- --check`)