### PR TITLE
fix: add missing typed config accessors

### DIFF
--- a/crates/cascette-formats/src/config/build_config.rs
+++ b/crates/cascette-formats/src/config/build_config.rs
@@ -14,6 +14,15 @@ pub struct BuildConfig {
     entries: HashMap<String, Vec<String>>,
 }
 
+/// A partial priority entry mapping a content key to a download priority
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartialPriority {
+    /// Content key identifier
+    pub key: String,
+    /// Download priority value
+    pub priority: u32,
+}
+
 /// Information about a referenced build file
 #[derive(Debug, Clone)]
 pub struct BuildInfo {
@@ -83,6 +92,11 @@ impl BuildConfig {
             "build-uid",
             "build-product",
             "build-playbuild-installer",
+            "build-partial-priority",
+            "build-playtime-url",
+            "build-product-espec",
+            "vfs-root",
+            "vfs-root-size",
         ];
 
         // Write header comment
@@ -323,6 +337,134 @@ impl BuildConfig {
             .map(std::string::String::as_str)
     }
 
+    /// Get size file information
+    ///
+    /// Format: `size = CONTENT_KEY [ENCODING_KEY]`, `size-size = SIZE [ENCODING_SIZE]`
+    pub fn size(&self) -> Option<BuildInfo> {
+        let values = self.entries.get("size")?;
+        let content_key = values.first()?.clone();
+        let encoding_key = values.get(1).cloned();
+
+        let size = self
+            .entries
+            .get("size-size")
+            .and_then(|v| v.get(1))
+            .and_then(|s| s.parse().ok());
+
+        Some(BuildInfo {
+            content_key,
+            encoding_key,
+            size,
+        })
+    }
+
+    /// Get VFS root file information
+    ///
+    /// Format: `vfs-root = CONTENT_KEY [ENCODING_KEY]`, `vfs-root-size = SIZE [ENCODING_SIZE]`
+    pub fn vfs_root(&self) -> Option<BuildInfo> {
+        let values = self.entries.get("vfs-root")?;
+        let content_key = values.first()?.clone();
+        let encoding_key = values.get(1).cloned();
+
+        let size = self
+            .entries
+            .get("vfs-root-size")
+            .and_then(|v| v.get(1))
+            .and_then(|s| s.parse().ok());
+
+        Some(BuildInfo {
+            content_key,
+            encoding_key,
+            size,
+        })
+    }
+
+    /// Get build playtime URL
+    pub fn build_playtime_url(&self) -> Option<&str> {
+        self.entries
+            .get("build-playtime-url")
+            .and_then(|v| v.first())
+            .map(std::string::String::as_str)
+    }
+
+    /// Get build product espec
+    pub fn build_product_espec(&self) -> Option<&str> {
+        self.entries
+            .get("build-product-espec")
+            .and_then(|v| v.first())
+            .map(std::string::String::as_str)
+    }
+
+    /// Get VFS file entries
+    ///
+    /// Keys: `vfs-1` through `vfs-N` with parallel `vfs-1-size` etc.
+    /// Each entry uses the dual-hash format. Returns entries with their 1-based index.
+    /// Iterates sequentially from 1 and stops at the first missing index.
+    pub fn vfs_entries(&self) -> Vec<(u32, BuildInfo)> {
+        let mut result = Vec::new();
+        let mut index = 1u32;
+
+        loop {
+            let key = format!("vfs-{index}");
+            let Some(values) = self.entries.get(&key) else {
+                break;
+            };
+
+            let content_key = match values.first() {
+                Some(k) => k.clone(),
+                None => break,
+            };
+            let encoding_key = values.get(1).cloned();
+
+            let size_key = format!("vfs-{index}-size");
+            let size = self
+                .entries
+                .get(&size_key)
+                .and_then(|v| v.get(1))
+                .and_then(|s| s.parse().ok());
+
+            result.push((
+                index,
+                BuildInfo {
+                    content_key,
+                    encoding_key,
+                    size,
+                },
+            ));
+            index += 1;
+        }
+
+        result
+    }
+
+    /// Get build partial priority entries
+    ///
+    /// Format: `build-partial-priority = key1:priority1,key2:priority2,...`
+    ///
+    /// Values are stored as a single comma-separated string. Malformed entries are skipped.
+    pub fn build_partial_priority(&self) -> Vec<PartialPriority> {
+        let Some(values) = self.entries.get("build-partial-priority") else {
+            return Vec::new();
+        };
+
+        // The value is stored as space-separated tokens (from the generic parser),
+        // but the actual format is comma-separated within a single value.
+        // Join back and split on commas.
+        let joined = values.join(" ");
+        joined
+            .split(',')
+            .filter_map(|entry| {
+                let entry = entry.trim();
+                let (key, priority_str) = entry.rsplit_once(':')?;
+                let priority = priority_str.parse::<u32>().ok()?;
+                Some(PartialPriority {
+                    key: key.to_string(),
+                    priority,
+                })
+            })
+            .collect()
+    }
+
     /// Validate the configuration
     pub fn validate(&self) -> Result<(), ValidationError> {
         // Must have root
@@ -408,5 +550,200 @@ impl crate::CascFormat for BuildConfig {
     }
 }
 
-// NOTE: Tests that used external test data files were removed after tools restructuring
-// The existing unit tests above provide sufficient coverage for BuildConfig functionality
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn hash(n: u8) -> String {
+        format!("{:032x}", n)
+    }
+
+    #[test]
+    fn test_size_accessor() {
+        let mut config = BuildConfig::new();
+        config.set("size", vec![hash(1), hash(2)]);
+        config.set("size-size", vec!["100".into(), "200".into()]);
+
+        let info = config.size().expect("size should be present");
+        assert_eq!(info.content_key, hash(1));
+        assert_eq!(info.encoding_key.as_deref(), Some(hash(2)).as_deref());
+        assert_eq!(info.size, Some(200));
+    }
+
+    #[test]
+    fn test_size_missing() {
+        let config = BuildConfig::new();
+        assert!(config.size().is_none());
+    }
+
+    #[test]
+    fn test_vfs_root_accessor() {
+        let mut config = BuildConfig::new();
+        config.set("vfs-root", vec![hash(3), hash(4)]);
+        config.set("vfs-root-size", vec!["300".into(), "400".into()]);
+
+        let info = config.vfs_root().expect("vfs_root should be present");
+        assert_eq!(info.content_key, hash(3));
+        assert_eq!(info.encoding_key.as_deref(), Some(hash(4)).as_deref());
+        assert_eq!(info.size, Some(400));
+    }
+
+    #[test]
+    fn test_vfs_root_missing() {
+        let config = BuildConfig::new();
+        assert!(config.vfs_root().is_none());
+    }
+
+    #[test]
+    fn test_build_playtime_url() {
+        let mut config = BuildConfig::new();
+        config.set(
+            "build-playtime-url",
+            vec!["https://example.com/playtime".into()],
+        );
+
+        assert_eq!(
+            config.build_playtime_url(),
+            Some("https://example.com/playtime")
+        );
+    }
+
+    #[test]
+    fn test_build_playtime_url_missing() {
+        let config = BuildConfig::new();
+        assert!(config.build_playtime_url().is_none());
+    }
+
+    #[test]
+    fn test_build_product_espec() {
+        let mut config = BuildConfig::new();
+        config.set("build-product-espec", vec!["wow_classic".into()]);
+
+        assert_eq!(config.build_product_espec(), Some("wow_classic"));
+    }
+
+    #[test]
+    fn test_build_product_espec_missing() {
+        let config = BuildConfig::new();
+        assert!(config.build_product_espec().is_none());
+    }
+
+    #[test]
+    fn test_build_partial_priority() {
+        let mut config = BuildConfig::new();
+        config.set(
+            "build-partial-priority",
+            vec!["speech:0,world:1,base:2".into()],
+        );
+
+        let priorities = config.build_partial_priority();
+        assert_eq!(priorities.len(), 3);
+        assert_eq!(priorities[0].key, "speech");
+        assert_eq!(priorities[0].priority, 0);
+        assert_eq!(priorities[1].key, "world");
+        assert_eq!(priorities[1].priority, 1);
+        assert_eq!(priorities[2].key, "base");
+        assert_eq!(priorities[2].priority, 2);
+    }
+
+    #[test]
+    fn test_build_partial_priority_malformed_skipped() {
+        let mut config = BuildConfig::new();
+        config.set(
+            "build-partial-priority",
+            vec!["speech:0,bad_entry,world:abc,base:2".into()],
+        );
+
+        let priorities = config.build_partial_priority();
+        assert_eq!(priorities.len(), 2);
+        assert_eq!(priorities[0].key, "speech");
+        assert_eq!(priorities[1].key, "base");
+    }
+
+    #[test]
+    fn test_build_partial_priority_empty() {
+        let config = BuildConfig::new();
+        assert!(config.build_partial_priority().is_empty());
+    }
+
+    #[test]
+    fn test_vfs_entries() {
+        let mut config = BuildConfig::new();
+        config.set("vfs-1", vec![hash(10), hash(11)]);
+        config.set("vfs-1-size", vec!["1000".into(), "1100".into()]);
+        config.set("vfs-2", vec![hash(20), hash(21)]);
+        config.set("vfs-2-size", vec!["2000".into(), "2100".into()]);
+
+        let entries = config.vfs_entries();
+        assert_eq!(entries.len(), 2);
+
+        assert_eq!(entries[0].0, 1);
+        assert_eq!(entries[0].1.content_key, hash(10));
+        assert_eq!(
+            entries[0].1.encoding_key.as_deref(),
+            Some(hash(11)).as_deref()
+        );
+        assert_eq!(entries[0].1.size, Some(1100));
+
+        assert_eq!(entries[1].0, 2);
+        assert_eq!(entries[1].1.content_key, hash(20));
+    }
+
+    #[test]
+    fn test_vfs_entries_stops_at_gap() {
+        let mut config = BuildConfig::new();
+        config.set("vfs-1", vec![hash(10)]);
+        // Skip vfs-2
+        config.set("vfs-3", vec![hash(30)]);
+
+        let entries = config.vfs_entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, 1);
+    }
+
+    #[test]
+    fn test_vfs_entries_empty() {
+        let config = BuildConfig::new();
+        assert!(config.vfs_entries().is_empty());
+    }
+
+    #[test]
+    fn test_round_trip_new_accessors() {
+        let mut config = BuildConfig::new();
+        // Required fields for a valid-ish config
+        config.set("root", vec![hash(1)]);
+        config.set("encoding", vec![hash(2), hash(3)]);
+        config.set("encoding-size", vec!["100".into(), "200".into()]);
+
+        // New fields
+        config.set("size", vec![hash(4), hash(5)]);
+        config.set("size-size", vec!["300".into(), "400".into()]);
+        config.set("vfs-root", vec![hash(6), hash(7)]);
+        config.set("vfs-root-size", vec!["500".into(), "600".into()]);
+        config.set("build-playtime-url", vec!["https://example.com/pt".into()]);
+        config.set("build-product-espec", vec!["wow".into()]);
+        config.set("build-partial-priority", vec!["speech:0,world:1".into()]);
+
+        let built = config.build();
+        let reparsed = BuildConfig::parse(&built[..]).expect("reparse should succeed");
+
+        // Verify all new accessors survive round-trip
+        let size = reparsed.size().expect("size");
+        assert_eq!(size.content_key, hash(4));
+        assert_eq!(size.size, Some(400));
+
+        let vfs_root = reparsed.vfs_root().expect("vfs_root");
+        assert_eq!(vfs_root.content_key, hash(6));
+
+        assert_eq!(
+            reparsed.build_playtime_url(),
+            Some("https://example.com/pt")
+        );
+        assert_eq!(reparsed.build_product_espec(), Some("wow"));
+
+        let priorities = reparsed.build_partial_priority();
+        assert_eq!(priorities.len(), 2);
+        assert_eq!(priorities[0].key, "speech");
+    }
+}

--- a/crates/cascette-formats/src/config/mod.rs
+++ b/crates/cascette-formats/src/config/mod.rs
@@ -8,7 +8,7 @@ mod cdn_config;
 mod patch_config;
 mod product_config;
 
-pub use build_config::{BuildConfig, BuildInfo};
+pub use build_config::{BuildConfig, BuildInfo, PartialPriority};
 pub use cdn_config::{ArchiveInfo, CdnConfig};
 pub use patch_config::{PatchConfig, PatchEntry};
 pub use product_config::{


### PR DESCRIPTION
## Summary

- Add 6 typed accessors to `BuildConfig`: `size()`, `vfs_root()`, `build_playtime_url()`, `build_product_espec()`, `build_partial_priority()`, `vfs_entries()`
- Add 3 typed accessors to `CdnConfig`: `patch_file_index()`, `patch_file_index_size()`, `patch_file_indices()`
- Add `PartialPriority` type for comma-separated `key:priority` parsing
- Update `build()` key orderings for deterministic serialization
- Export `PartialPriority` from `config` module

These fields are parsed by Agent.exe's `tact::ConfigReader` but previously only accessible via raw `get()` on the HashMap.

## Test plan

- [x] Each accessor returns correct values when key is present
- [x] Each accessor returns `None`/empty vec when key is missing
- [x] `build_partial_priority` skips malformed entries
- [x] `vfs_entries` stops at first missing index
- [x] Round-trip: `build()` then `parse()` preserves all new fields
- [x] `cargo clippy -p cascette-formats -- -D warnings` passes
- [x] `cargo fmt -p cascette-formats -- --check` passes