### PR TITLE
fix: correct TVFS and root file format issues

### DIFF
--- a/crates/cascette-formats/src/root/file.rs
+++ b/crates/cascette-formats/src/root/file.rs
@@ -72,11 +72,11 @@ impl RootFile {
             // Try to parse next block
             match RootBlock::parse(reader, version, has_named_files) {
                 Ok(block) => {
-                    if block.num_records() == 0 {
-                        // Empty block, we've reached the end
-                        break;
+                    // Skip empty blocks -- they can appear between valid blocks.
+                    // EOF termination is handled by the position check above.
+                    if block.num_records() > 0 {
+                        blocks.push(block);
                     }
-                    blocks.push(block);
                 }
                 Err(e) => {
                     // If we haven't parsed any blocks yet, this is a real error

--- a/crates/cascette-formats/src/root/mod.rs
+++ b/crates/cascette-formats/src/root/mod.rs
@@ -1,7 +1,12 @@
 //! Root file format support for NGDP/CASC systems
 //!
-//! This module provides complete parsing and building support for CASC root files
-//! across all four format versions (V1-V4) used throughout World of Warcraft's history.
+//! This module provides parsing and building support for the World of Warcraft
+//! root file format across versions V1-V4. The root file maps `FileDataID`
+//! values and path name hashes to content keys.
+//!
+//! **Note:** This root format is WoW-specific. Other CASC-based games (e.g.
+//! Diablo IV, Overwatch) use different root file formats with distinct
+//! structures and semantics.
 //!
 //! # Root File Versions
 //!

--- a/crates/cascette-formats/src/tvfs/utils.rs
+++ b/crates/cascette-formats/src/tvfs/utils.rs
@@ -59,7 +59,6 @@ pub fn write_varint(value: u32, data: &mut Vec<u8>) {
 }
 
 /// Calculate the size needed to encode a variable-length integer
-#[allow(dead_code)] // Public API function
 pub fn varint_size(value: u32) -> usize {
     if value == 0 {
         1


### PR DESCRIPTION
## Summary

- Fix VFS entry size calculation: use 22-byte disk size constant instead of `size_of::<VfsEntry>()` (24 bytes due to alignment padding)
- Fix TVFS builder path table size: use exact `varint_size()` instead of hardcoded 5-byte approximation
- Fix root empty block parsing: skip empty intermediate blocks instead of breaking (EOF check handles termination)
- Fix TSFM endianness preservation: store magic in `RootHeader`, write little-endian fields for TSFM headers
- Add WoW-specific note to root module documentation

## Test plan

- [x] All 629 cascette-formats tests pass
- [x] New tests for TSFM V2 and V3V4 round-trips
- [x] New test for little-endian RootHeaderInfo round-trip
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt` check passes