### PR TITLE
fix: cast mode_t to c_uint for variadic shm_open on macOS

### DIFF
--- a/crates/cascette-client-storage/src/shmem/legacy.rs
+++ b/crates/cascette-client-storage/src/shmem/legacy.rs
@@ -1284,7 +1284,7 @@ mod unix {
     use std::slice;
 
     use libc::{MAP_SHARED, O_CREAT, O_RDWR, PROT_READ, PROT_WRITE, S_IRUSR, S_IWUSR};
-    use libc::{c_void, mode_t, off_t, size_t};
+    use libc::{c_uint, c_void, mode_t, off_t, size_t};
     use libc::{close, ftruncate, mmap, munmap, shm_open, shm_unlink};
 
     use crate::{Result, StorageError};
@@ -1311,7 +1311,7 @@ mod unix {
                 shm_open(
                     c_name.as_ptr(),
                     O_CREAT | O_RDWR,
-                    (S_IRUSR | S_IWUSR) as mode_t,
+                    (S_IRUSR | S_IWUSR) as mode_t as c_uint,
                 )
             };
 

--- a/crates/cascette-client-storage/src/shmem/platform_unix.rs
+++ b/crates/cascette-client-storage/src/shmem/platform_unix.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 use std::{ptr, slice};
 
 use libc::{MAP_SHARED, O_CREAT, O_RDWR, PROT_READ, PROT_WRITE, S_IRUSR, S_IWUSR};
-use libc::{c_void, mode_t, off_t, size_t};
+use libc::{c_uint, c_void, mode_t, off_t, size_t};
 use libc::{close, ftruncate, mmap, munmap, shm_open};
 
 use crate::{Result, StorageError};
@@ -66,7 +66,7 @@ impl PlatformShmem {
             shm_open(
                 c_name.as_ptr(),
                 O_CREAT | O_RDWR,
-                (S_IRUSR | S_IWUSR) as mode_t,
+                (S_IRUSR | S_IWUSR) as mode_t as c_uint,
             )
         };
 


### PR DESCRIPTION
## Summary

- Casts `mode_t` to `c_uint` in `shm_open` variadic calls in `platform_unix.rs` and `legacy.rs`
- On macOS, `mode_t` is `u16`, which Rust rejects for variadic FFI arguments (must be at least `c_uint`/`u32`)
- On Linux `mode_t` is already `u32`, so the extra cast is a no-op

Closes #42

## Test plan

- [ ] CI passes on Linux
- [ ] Verify `cargo check -p cascette-client-storage` succeeds on macOS